### PR TITLE
feat(Broadcom): Add initial Conv2d Tiling

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -611,11 +611,30 @@ const WgpDetails *getAndroidBaseline2022WgpDetails() {
   return &androidWgp;
 }
 
+const WgpDetails *getVideocoreWgpDetails() {
+  // The following details are taken from running vulkaninfo on the RPI5.
+  // The broadcom chip does not have much docuentation but for the most part
+  // we know the workgroup and subgroup sizes. However, memory and thread counts
+  // are more of a guess as they are not explicit in the log output.
+
+  auto computeBitwdiths = ComputeBitwidths::Int32 | ComputeBitwidths::FP32;
+  auto storageBitwidths = StorageBitwidths::B32;
+  // clang-format off
+  static const WgpDetails androidWgp = {
+      computeBitwdiths,    storageBitwidths,   SubgroupOps::None,
+      DotProductOps::None, /*mmaCount=*/0,     /*mmaOps=*/nullptr,
+      {16, 16},            {256, 256, 256},     32,
+      16384,
+      {65535, 65535, 65535}};
+  // clang-format on
+  return &androidWgp;
+}
+
 std::optional<TargetDetails> getBroadcomProfileDetails(StringRef target) {
-  const WgpDetails *baseline2022Wgp = getAndroidBaseline2022WgpDetails();
+  const WgpDetails *baselineWgp = getVideocoreWgpDetails();
 
   return llvm::StringSwitch<std::optional<TargetDetails>>(target.lower())
-      .Case("videocore_vii", TargetDetails{baseline2022Wgp, nullptr})
+      .Case("videocore_vii", TargetDetails{baselineWgp, nullptr})
       .Default(std::nullopt);
 }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/VideoCoreConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/VideoCoreConfig.cpp
@@ -11,11 +11,21 @@
 //===----------------------------------------------------------------------===//
 
 #include <array>
+#include <cstdint>
 
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/SPIRV/KernelConfig.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/LogicalResult.h"
 
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 
+#define DEBUG_TYPE "iree-spirv-videocore-config"
+
+using CodeGenPipeline =
+    mlir::iree_compiler::IREE::Codegen::DispatchLoweringPassPipeline;
 namespace mlir::iree_compiler::detail {
 
 static LogicalResult setVideoCoreMatmulConfig(linalg::LinalgOp op,
@@ -30,6 +40,151 @@ static LogicalResult setVideoCoreMatmulConfig(linalg::LinalgOp op,
   const std::array<int64_t, 2> workgroupXY = {16, 16};
   const std::array<int64_t, 3> threadMNK = {4, 4, 4};
   return setMatmulOpConfig(target, op, workgroupXY, threadMNK);
+}
+
+static int64_t getWorkgroupTiling(int64_t &remainingThreads,
+                                  int64_t dimensionSize) {
+  // Find the largest power of two value that can evenly divide the dimension
+  // and take that away from the pool of available threads.
+  auto result = dimensionSize & (~(dimensionSize - 1));
+  remainingThreads = std::max(result / remainingThreads, 1ll);
+  return result;
+}
+
+static LogicalResult setConvOpForVideoCoreConfig(linalg::LinalgOp op,
+                                                 int64_t threadsPerWorkGroup,
+                                                 int64_t optimalThreadTiling) {
+  auto convDimsOrFailure = linalg::inferConvolutionDims(op);
+  if (failed(convDimsOrFailure))
+    return failure();
+  auto inputType =
+      llvm::cast<ShapedType>(op.getDpsInputOperand(0)->get().getType());
+  // Restrict the tilings to just float32 as we have not investigated the
+  // optimal tiling for f16 or other types yet.
+  if (!inputType.getElementType().isF32()) {
+    return failure();
+  }
+  const mlir::linalg::ConvolutionDimensions &convDims = *convDimsOrFailure;
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "conv: " << op;
+    llvm::dbgs() << "\nconv batch dim: ";
+    llvm::interleaveComma(convDims.batch, llvm::dbgs());
+    llvm::dbgs() << "\nconv output window dims: ";
+    llvm::interleaveComma(convDims.outputImage, llvm::dbgs());
+    llvm::dbgs() << "\nconv output channel dim: ";
+    llvm::interleaveComma(convDims.outputChannel, llvm::dbgs());
+    llvm::dbgs() << "\nconv filter window dims: ";
+    llvm::interleaveComma(convDims.filterLoop, llvm::dbgs());
+    llvm::dbgs() << "\nconv input channel dims: ";
+    llvm::interleaveComma(convDims.inputChannel, llvm::dbgs());
+    llvm::dbgs() << "\nconv depth multiplier: ";
+    llvm::interleaveComma(convDims.depth, llvm::dbgs());
+    llvm::dbgs() << "\n";
+  });
+
+  SmallVector<int64_t> loopRanges = op.getStaticLoopRanges();
+  const int ohIndex = convDims.outputImage.front();
+  const int owIndex = convDims.outputImage.back();
+  const int64_t oh = loopRanges[ohIndex];
+  const int64_t ow = loopRanges[owIndex];
+
+  int ocIndex;
+  if (!convDims.outputChannel.empty()) {
+    assert(convDims.outputChannel.size() == 1);
+    ocIndex = convDims.outputChannel.front();
+  } else if (!convDims.depth.empty()) {
+    // For depthwise convolution ops with multipler 1, we have the same
+    // input/filter/output channel size, which is being categorized as the
+    // multipler.
+    assert(convDims.depth.size() == 1);
+    ocIndex = convDims.depth.front();
+  } else {
+    // For pooling ops, the input/output channel size will be categorized
+    // as the additional batch dimension.
+    assert(convDims.batch.size() == 2);
+    ocIndex = convDims.batch.back();
+  }
+
+  Type outputType = op.getDpsInitOperand(0)->get().getType();
+  ArrayRef<int64_t> outputShape = llvm::cast<ShapedType>(outputType).getShape();
+  if ((convDims.inputChannel.empty() ||
+       ShapedType::isDynamic(convDims.inputChannel.front())) ||
+      llvm::any_of(outputShape.drop_front(), ShapedType::isDynamic)) {
+    return failure();
+  }
+
+  // Output tilings for the SPIRV Vectorize Pipeline. There are 4 stages to
+  // tiling with this particular pipeline. Workgroup, Thread, Reduction and
+  // Vector(Window).
+  TileSizesListType tileSizes;
+  const int64_t outputChannelSize = loopRanges[ocIndex];
+
+  const bool isNCHW = ocIndex < ohIndex;
+  if (!isNCHW) {
+    // TODO(ROO-89): implement the NHWC case
+    return failure();
+  }
+
+  // Workgroup tiling is calculated by finding the largest power-of-two value
+  // that is an exact multiple of that output dimension size. As we are
+  // performing a convolution, the input elements required for one output is 2D
+  // with a size of FxF, meaning the filter size. The algorithm below will try
+  // to find the largest tile in the OW dimension first and subtract from the
+  // available threads for the later dimensions. The idea being all threads will
+  // need generally the same row from the input tensor when calculating their
+  // output. Generating a sequential access pattern.
+  SmallVector<int64_t> workgroupTiling(4, 1); // (N, OC, OH, OW)
+  workgroupTiling[3] = getWorkgroupTiling(threadsPerWorkGroup, ow);
+  workgroupTiling[2] = getWorkgroupTiling(threadsPerWorkGroup, oh);
+  workgroupTiling[1] =
+      getWorkgroupTiling(threadsPerWorkGroup, outputChannelSize);
+  tileSizes.push_back(workgroupTiling);
+
+  // Remember OC->Z, OW->Y and OH->X
+  // The rule for the workgroup size is as follows:
+  //    X = WG_TILING_X / 4
+  //    Y = WG_TILING_Y
+  //    Z = WG_TILING_Z / 4
+  // This configuration seems to work best for the GPU. There is no concrete
+  // reasoning behind it.
+  SmallVector<int64_t, 3> workgroupSize(3, 1); // (X, Y, Z)
+  workgroupSize[0] = std::max(workgroupTiling[3] / 4, 1ll);
+  workgroupSize[1] = workgroupTiling[2];
+  workgroupSize[2] = std::max(workgroupTiling[1] / 4, 1ll);
+
+  // For each thread we want to maximize the number of output elements in OW
+  // that each thread calculates. That is why we do not calculate the output
+  // elements of the other dimensions but simply the ones in the OW row.
+  // Attempting to keep the memory accesses from the input matrix
+  // in-line for all the output elements calculated in a thread.
+  SmallVector<int64_t> threadTiling = {1, 1, 1,
+                                       optimalThreadTiling}; // (N, OC, OH, OW)
+  tileSizes.push_back(threadTiling);
+
+  // The reduction tiling is the operation performing the convolution and is
+  // usually where the vectorization is applied. I.e. the vector-multiply-add
+  // operation.
+  SmallVector<int64_t> reductionTiling(loopRanges.size(), 0);
+  reductionTiling[convDims.inputChannel.front()] = 4;
+  reductionTiling[convDims.filterLoop.front()] = 1;
+  reductionTiling[convDims.filterLoop.back()] = 1;
+  tileSizes.push_back(reductionTiling);
+
+  // Tile along OH by size 1 to enable downsizing 2-D convolution to 1-D.
+  // Meaning [N, OC, OH, OW] will be likely something like [1, 1, 1, OW]
+  // So the loop performing the convolution will traverse only over a single
+  // row. Keeping the memory accesses coalesced.
+  SmallVector<int64_t> windowTileSizes(4, 0);
+  windowTileSizes[ohIndex] = 1;
+  tileSizes.push_back(windowTileSizes);
+
+  auto pipeline = CodeGenPipeline::SPIRVBaseVectorize;
+  auto funcOp = op->getParentOfType<mlir::FunctionOpInterface>();
+  // This will annotate the dispatch function with the workgroup size and the
+  // linalg.conv operation with the tilings we have chosen.
+  return setOpConfigAndEntryPointFnTranslation(funcOp, op, tileSizes, pipeline,
+                                               workgroupSize);
 }
 
 //===----------------------------------------------------------------------===//
@@ -47,7 +202,16 @@ LogicalResult setVideoCoreCodeGenConfig(IREE::GPU::TargetAttr target,
     return setVideoCoreMatmulConfig(linalgOp, target);
   }
 
-  // TODO(ROO-68): add optimized tilings for Conv2d:
+  // The IREE heuristic got us quite good performance around 60s for ResNet18
+  // using the below settings. if (auto convOp =
+  // dyn_cast<linalg::ConvolutionOpInterface>(rootOp)) {
+  //   return setConvOpConfig(cast<linalg::LinalgOp>(rootOp), 256, 4));
+  // }
+
+  // With this heuristic we get around 3.2s with ResNet18 on the RPI5 GPU
+  if (auto convOp = dyn_cast<linalg::ConvolutionOpInterface>(rootOp)) {
+    return setConvOpForVideoCoreConfig(cast<linalg::LinalgOp>(rootOp), 256, 4);
+  }
 
   return failure();
 }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
@@ -27,6 +27,7 @@ iree_lit_test_suite(
             "config_amd_matmul_cooperative_ops.mlir",
             "config_amd_matvec.mlir",
             "config_broadcom_matmul.mlir",
+            "config_broadcom_conv.mlir",
             "config_default_conv.mlir",
             "config_default_linalg_ext_ops.mlir",
             "config_default_linalg_ops.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_lit_test_suite(
     "config_amd_matmul.mlir"
     "config_amd_matmul_cooperative_ops.mlir"
     "config_amd_matvec.mlir"
+    "config_broadcom_conv.mlir"
     "config_broadcom_matmul.mlir"
     "config_default_conv.mlir"
     "config_default_linalg_ext_ops.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_broadcom_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_broadcom_conv.mlir
@@ -1,0 +1,267 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=videocore_vii --pass-pipeline='builtin.module(iree-spirv-select-lowering-strategy-pass)' %s | FileCheck %s
+
+// Convolution with consumer pointwise ops.
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+func.func @nhwc_conv_pointwise_112x112x32() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %c112 = arith.constant 112 : index
+  %c32 = arith.constant 32 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !flow.dispatch.tensor<readonly:tensor<1x112x112x32xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !flow.dispatch.tensor<readonly:tensor<1x225x225x3xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !flow.dispatch.tensor<readonly:tensor<3x3x3x32xf32>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) : !flow.dispatch.tensor<writeonly:tensor<1x112x112x32xf32>>
+  %4 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 112, 112, 32], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<1x112x112x32xf32>> -> tensor<1x112x112x32xf32>
+  %5 = tensor.empty() : tensor<1x112x112x32xf32>
+  %6 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [1, 225, 225, 3], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<1x225x225x3xf32>> -> tensor<1x225x225x3xf32>
+  %7 = flow.dispatch.tensor.load %2, offsets = [0, 0, 0, 0], sizes = [3, 3, 3, 32], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x3x32xf32>> -> tensor<3x3x3x32xf32>
+  %8 = tensor.empty() : tensor<1x112x112x32xf32>
+  %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32>
+  %10 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%6, %7 : tensor<1x225x225x3xf32>, tensor<3x3x3x32xf32>) outs(%9 : tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32>
+  %11 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%10, %4 : tensor<1x112x112x32xf32>, tensor<1x112x112x32xf32>) outs(%5 : tensor<1x112x112x32xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %12 = arith.subf %in, %in_0 : f32
+    linalg.yield %12 : f32
+  } -> tensor<1x112x112x32xf32>
+  flow.dispatch.tensor.store %11, %3, offsets = [0, 0, 0, 0], sizes = [1, 112, 112, 32], strides = [1, 1, 1, 1] : tensor<1x112x112x32xf32> -> !flow.dispatch.tensor<writeonly:tensor<1x112x112x32xf32>>
+  return
+}
+
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 32], [1, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize workgroup_size = [8, 2, 2]>
+//      CHECK: func.func @nhwc_conv_pointwise_112x112x32()
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK:   linalg.conv_2d_nhwc_hwcf
+// CHECK-SAME:       lowering_config = #[[CONFIG]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @nchw_conv_2x1280x8x8() {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<2x1280x10x10xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<1280x1280x3x3xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !flow.dispatch.tensor<readwrite:tensor<2x1280x8x8xf32>>
+  %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 1280, 10, 10], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x1280x10x10xf32>> -> tensor<2x1280x10x10xf32>
+  %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [1280, 1280, 3, 3], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<1280x1280x3x3xf32>> -> tensor<1280x1280x3x3xf32>
+  %5 = flow.dispatch.tensor.load %2, offsets = [0, 0, 0, 0], sizes = [2, 1280, 8, 8], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readwrite:tensor<2x1280x8x8xf32>> -> tensor<2x1280x8x8xf32>
+  %6 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%3, %4 : tensor<2x1280x10x10xf32>, tensor<1280x1280x3x3xf32>) outs(%5 : tensor<2x1280x8x8xf32>) -> tensor<2x1280x8x8xf32>
+  flow.dispatch.tensor.store %6, %2, offsets = [0, 0, 0, 0], sizes = [2, 1280, 8, 8], strides = [1, 1, 1, 1] : tensor<2x1280x8x8xf32> -> !flow.dispatch.tensor<readwrite:tensor<2x1280x8x8xf32>>
+  return
+}
+
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 256, 8, 8], [1, 1, 1, 4], [0, 0, 0, 0, 4, 1, 1], [0, 0, 1, 0]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize workgroup_size = [2, 8, 64]>
+//      CHECK: func.func @nchw_conv_2x1280x8x8()
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK:   linalg.conv_2d_nchw_fchw
+// CHECK-SAME:       lowering_config = #[[CONFIG]]
+
+// -----
+
+// Conv - large OC - distribute to only one workgroup dimension.
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @conv_112x112x512() {
+  %c0 = arith.constant 0 : index
+  %c512 = arith.constant 512 : index
+  %c112 = arith.constant 112 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !flow.dispatch.tensor<readonly:tensor<1x225x225x3xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !flow.dispatch.tensor<readonly:tensor<3x3x3x512xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !flow.dispatch.tensor<writeonly:tensor<1x112x112x512xf32>>
+  %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 225, 225, 3], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<1x225x225x3xf32>> -> tensor<1x225x225x3xf32>
+  %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 3, 512], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x3x512xf32>> -> tensor<3x3x3x512xf32>
+  %5 = tensor.empty() : tensor<1x112x112x512xf32>
+  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x112x112x512xf32>) -> tensor<1x112x112x512xf32>
+  %7 = linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x225x225x3xf32>, tensor<3x3x3x512xf32>) outs(%6 : tensor<1x112x112x512xf32>) -> tensor<1x112x112x512xf32>
+  flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 112, 112, 512], strides = [1, 1, 1, 1] : tensor<1x112x112x512xf32> -> !flow.dispatch.tensor<writeonly:tensor<1x112x112x512xf32>>
+  return
+}
+
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 8, 128], [1, 1, 8, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize workgroup_size = [32, 1, 1]>
+//      CHECK: func.func @conv_112x112x512()
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK:   linalg.conv_2d_nhwc_hwcf
+// CHECK-SAME:       lowering_config = #[[CONFIG]]
+
+// -----
+
+// Conv - medium OC/OW/OH - distribute to two workgroup dimensions.
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @conv_112x112x32() {
+  %c0 = arith.constant 0 : index
+  %c32 = arith.constant 32 : index
+  %c112 = arith.constant 112 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !flow.dispatch.tensor<readonly:tensor<1x225x225x3xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !flow.dispatch.tensor<readonly:tensor<3x3x3x32xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !flow.dispatch.tensor<writeonly:tensor<1x112x112x32xf32>>
+  %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 225, 225, 3], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<1x225x225x3xf32>> -> tensor<1x225x225x3xf32>
+  %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 3, 32], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x3x32xf32>> -> tensor<3x3x3x32xf32>
+  %5 = tensor.empty() : tensor<1x112x112x32xf32>
+  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32>
+  %7 = linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x225x225x3xf32>, tensor<3x3x3x32xf32>) outs(%6 : tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32>
+  flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 112, 112, 32], strides = [1, 1, 1, 1] : tensor<1x112x112x32xf32> -> !flow.dispatch.tensor<writeonly:tensor<1x112x112x32xf32>>
+  return
+}
+
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 32], [1, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize workgroup_size = [8, 2, 2]>
+//      CHECK: func.func @conv_112x112x32()
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK:   linalg.conv_2d_nhwc_hwcf
+// CHECK-SAME:       lowering_config = #[[CONFIG]]
+
+// -----
+
+// Conv - small OC/OW/OH - distribute to all three workgroup dimensions.
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @conv_16x16x16() {
+  %c0 = arith.constant 0 : index
+  %c16 = arith.constant 16 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !flow.dispatch.tensor<readonly:tensor<1x33x33x3xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !flow.dispatch.tensor<readonly:tensor<3x3x3x16xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !flow.dispatch.tensor<writeonly:tensor<1x16x16x16xf32>>
+  %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 33, 33, 3], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<1x33x33x3xf32>> -> tensor<1x33x33x3xf32>
+  %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 3, 16], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x3x16xf32>> -> tensor<3x3x3x16xf32>
+  %5 = tensor.empty() : tensor<1x16x16x16xf32>
+  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  %7 = linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x33x33x3xf32>, tensor<3x3x3x16xf32>) outs(%6 : tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 16, 16, 16], strides = [1, 1, 1, 1] : tensor<1x16x16x16xf32> -> !flow.dispatch.tensor<writeonly:tensor<1x16x16x16xf32>>
+  return
+}
+
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 16, 16], [1, 4, 2, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize workgroup_size = [4, 8, 1]>
+//      CHECK: func.func @conv_16x16x16()
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK:   linalg.conv_2d_nhwc_hwcf
+// CHECK-SAME:       lowering_config = #[[CONFIG]]
+
+// -----
+
+// Depthwise conv - small OC/OW/OH - distribute to all three workgroup dimensions.
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @dwconv_28x28x144() {
+  %c0 = arith.constant 0 : index
+  %c144 = arith.constant 144 : index
+  %c28 = arith.constant 28 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !flow.dispatch.tensor<readonly:tensor<1x57x57x144xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !flow.dispatch.tensor<readonly:tensor<3x3x144xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !flow.dispatch.tensor<writeonly:tensor<1x28x28x144xf32>>
+  %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [0, 57, 57, 144], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<1x57x57x144xf32>> -> tensor<1x57x57x144xf32>
+  %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [3, 3, 144], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x144xf32>> -> tensor<3x3x144xf32>
+  %5 = tensor.empty() : tensor<1x28x28x144xf32>
+  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x28x28x144xf32>) -> tensor<1x28x28x144xf32>
+  %7 = linalg.depthwise_conv_2d_nhwc_hwc {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x57x57x144xf32>, tensor<3x3x144xf32>) outs(%6 : tensor<1x28x28x144xf32>) -> tensor<1x28x28x144xf32>
+  flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 28, 28, 144], strides = [1, 1, 1, 1] : tensor<1x28x28x144xf32> -> !flow.dispatch.tensor<writeonly:tensor<1x28x28x144xf32>>
+  return
+}
+
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 16], [1, 2, 1, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize workgroup_size = [4, 4, 2]>
+//      CHECK: func.func @dwconv_28x28x144()
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK:   linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK-SAME:       lowering_config = #[[CONFIG]]
+
+// -----
+
+// Depthwise conv - tiny OC/OW/OH - starving the GPU.
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @dwconv_1x2x8() {
+  %c0 = arith.constant 0 : index
+  %c8 = arith.constant 8 : index
+  %c2 = arith.constant 2 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !flow.dispatch.tensor<readonly:tensor<1x3x5x8xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !flow.dispatch.tensor<readonly:tensor<3x3x8xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !flow.dispatch.tensor<writeonly:tensor<1x1x2x8xf32>>
+  %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 3, 5, 8], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<1x3x5x8xf32>> -> tensor<1x3x5x8xf32>
+  %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [3, 3, 8], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x8xf32>> -> tensor<3x3x8xf32>
+  %5 = tensor.empty() : tensor<1x1x2x8xf32>
+  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x1x2x8xf32>) -> tensor<1x1x2x8xf32>
+  %7 = linalg.depthwise_conv_2d_nhwc_hwc {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x3x5x8xf32>, tensor<3x3x8xf32>) outs(%6 : tensor<1x1x2x8xf32>) -> tensor<1x1x2x8xf32>
+  flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 1, 2, 8], strides = [1, 1, 1, 1] : tensor<1x1x2x8xf32> -> !flow.dispatch.tensor<writeonly:tensor<1x1x2x8xf32>>
+  return
+}
+
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 2, 8], [1, 1, 1, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize workgroup_size = [2, 2, 1]>
+//      CHECK: func.func @dwconv_1x2x8()
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK:   linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK-SAME:       lowering_config = #[[CONFIG]]
+
+
+// -----
+
+// Conv - medium OC/OW/OH with f16
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @conv_112x112x32xf16() {
+  %c0 = arith.constant 0 : index
+  %c32 = arith.constant 32 : index
+  %c112 = arith.constant 112 : index
+  %cst = arith.constant 0.000000e+00 : f16
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !flow.dispatch.tensor<readonly:tensor<1x225x225x3xf16>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !flow.dispatch.tensor<readonly:tensor<3x3x3x32xf16>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !flow.dispatch.tensor<writeonly:tensor<1x112x112x32xf16>>
+  %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 225, 225, 3], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<1x225x225x3xf16>> -> tensor<1x225x225x3xf16>
+  %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 3, 32], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x3x32xf16>> -> tensor<3x3x3x32xf16>
+  %5 = tensor.empty() : tensor<1x112x112x32xf16>
+  %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<1x112x112x32xf16>) -> tensor<1x112x112x32xf16>
+  %7 = linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x225x225x3xf16>, tensor<3x3x3x32xf16>) outs(%6 : tensor<1x112x112x32xf16>) -> tensor<1x112x112x32xf16>
+  flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 112, 112, 32], strides = [1, 1, 1, 1] : tensor<1x112x112x32xf16> -> !flow.dispatch.tensor<writeonly:tensor<1x112x112x32xf16>>
+  return
+}
+
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 16, 32], [1, 4, 2, 8], [0, 0, 0, 0, 1, 1, 8], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize workgroup_size = [4, 8, 1]>
+//      CHECK: func.func @conv_112x112x32xf16()
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK:   linalg.conv_2d_nhwc_hwcf
+// CHECK-SAME:       lowering_config = #[[CONFIG]]


### PR DESCRIPTION
It seems the best tiling result for the ukernel benchmark
example of 1x16x258x258 with a filter of 256x16x3x3 is around
2.7 GFlops.

The same on the raspberry pi CPU is around 28 GFlops. There is
still a lot of work to be done before the GPU has similar performance
to the CPU variant.