### PR TITLE
ConstExpr: expand to parents of nested consumers, fixes #18779

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
@@ -176,8 +176,15 @@ ConstExprAnalysis::ConstExprAnalysis(Operation *rootOp)
         for (auto &use : definingOp->getUses()) {
           Operation *useOp = use.getOwner();
           // Skip expanding of ops within dispatch or nested regions.
-          if (definingOp->getParentOp() != useOp->getParentOp())
+          if (definingOp->getParentOp() != useOp->getParentOp()) {
+            // check if we can expand to the parent op instead
+            if (auto parentOp = useOp->getParentOp()) {
+              if (definingOp->getParentOp() == parentOp->getParentOp()) {
+                expandToOp(parentOp);
+              }
+            }
             continue;
+          }
           expandToOp(useOp);
         }
       }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals_linalg.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals_linalg.mlir
@@ -60,3 +60,45 @@ module @broadcast_treated_as_leaf {
     util.return %1 : tensor<5x6xf32>
   }
 }
+
+// -----
+
+// Checks that a constantOp which only has a consumer within a nest gets hoisted
+
+module @nested_consumer {
+  // CHECK: util.global private @[[HOISTED:.*]] : tensor<2xf32>
+  // CHECK: util.initializer
+  // CHECK: util.func public @main
+  util.func @main(%arg0: tensor<2xindex>) -> tensor<1x2xf32> {
+    %const_t = arith.constant dense<[0.0, 1.0]> : tensor<2xf32>
+    %one = arith.constant 1.0 : f32
+    %empty = tensor.empty() : tensor<2xf32>
+    %add_one = linalg.generic { //constOp
+      indexing_maps = [
+        affine_map<(d0) -> (d0)>,
+        affine_map<(d0) -> (d0)>
+      ],
+      iterator_types = ["parallel"]
+    } ins(%const_t : tensor<2xf32>) outs(%empty: tensor<2xf32>) {
+      ^bb0(%in : f32, %out : f32):
+        %added = arith.addf %in, %one : f32
+        linalg.yield %added : f32
+    } -> tensor<2xf32>
+    // CHECK: %[[CONST:.*]] = util.global.load immutable @[[HOISTED]] : tensor<2xf32>
+    %empty2 = tensor.empty() : tensor<2xf32>
+    %loaded = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0) -> (d0)>,
+        affine_map<(d0) -> (d0)>
+      ],
+      iterator_types = ["parallel"]
+    } ins(%arg0 : tensor<2xindex>) outs(%empty2 : tensor<2xf32>) {
+      ^bb0(%in: index, %out: f32):
+        //CHECK %[[.*]] = tensor.extract %[[CONST]][%in] : tensor<2xf32>
+        %extracted = tensor.extract %add_one[%in] : tensor<2xf32> // consumer
+        linalg.yield %extracted : f32
+    } -> tensor<2xf32>
+    %reshaped = tensor.expand_shape %loaded [[0, 1]] output_shape[1, 2]: tensor<2xf32> into tensor<1x2xf32>
+    util.return %reshaped : tensor<1x2xf32>
+  }
+}


### PR DESCRIPTION
This change fixes the problem where constExprs, which only have a consumer within a nested region, can end up with 0 consumers. This leads to the issue that these constExprs can't get hoisted, as the ConstExprHoistingPolicy will determine them as invalid because they can't have a legal escape if they don't have any consumers. A more detailed description of what happens is in https://github.com/iree-org/iree/issues/18779.