### PR TITLE
[torch-mlir] roo-91: memory leak fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,7 +33,7 @@
 	url = https://github.com/iree-org/stablehlo.git
 [submodule "third_party/torch-mlir"]
 	path = third_party/torch-mlir
-	url = https://github.com/iree-org/torch-mlir.git
+	url = https://github.com/RooflineAI/torch-mlir.git
 [submodule "third_party/hip-build-deps"]
 	path = third_party/hip-build-deps
 	url = https://github.com/iree-org/hip-build-deps.git


### PR DESCRIPTION
Updates `torch-mlir` to point at our roofline fork to to the latest commit of `integrate-torch-mlir-20241122`.