### PR TITLE
fix(iree-opt): add missing passes and dialects

### DIFF
--- a/compiler/src/iree/compiler/Tools/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Tools/CMakeLists.txt
@@ -121,6 +121,7 @@ iree_cc_library(
     MLIRTensorTransformOps
     MLIRVectorTransformOps
     MLIRTransformLoopExtension
+    MLIRComplexToStandard
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
+++ b/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
@@ -36,6 +36,7 @@
 #include "mlir/Dialect/MLProgram/IR/MLProgram.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/Dialect/MemRef/TransformOps/MemRefTransformOps.h"
 #include "mlir/Dialect/Mesh/IR/MeshDialect.h"
 #include "mlir/Dialect/NVGPU/IR/NVGPUDialect.h"
@@ -79,6 +80,7 @@ inline void registerMlirDialects(DialectRegistry &registry) {
                   mesh::MeshDialect,
                   memref::MemRefDialect,
                   ml_program::MLProgramDialect,
+                  NVVM::NVVMDialect,
                   pdl::PDLDialect,
                   pdl_interp::PDLInterpDialect,
                   scf::SCFDialect,

--- a/compiler/src/iree/compiler/Tools/init_mlir_passes.h
+++ b/compiler/src/iree/compiler/Tools/init_mlir_passes.h
@@ -26,6 +26,7 @@
 #include "mlir/Dialect/Shape/Transforms/Passes.h"
 #include "mlir/Dialect/Tosa/Transforms/Passes.h"
 #include "mlir/Dialect/Transform/Transforms/Passes.h"
+#include "mlir/Dialect/Bufferization/Transforms/Passes.h"
 #include "mlir/Transforms/Passes.h"
 
 namespace mlir {
@@ -50,6 +51,8 @@ inline void registerMlirPasses() {
   registerViewOpGraphPass();
   registerStripDebugInfoPass();
   registerSymbolDCEPass();
+  bufferization::registerBufferizationPasses();
+  registerConvertComplexToStandard();
 
   // Generic conversions
   registerReconcileUnrealizedCastsPass();


### PR DESCRIPTION
I found when parsing the outputs of the compiler pipeline and
attempting to elide the constants that there were some dialects and
passes missing from the tool. And when replaying a certain PassManager 
pipeline there were something passes missing form opt. 