### PR TITLE
fix(iree_hal_buffer_validate_access): Buffer access check ignores allowed access ANY

### DIFF
--- a/runtime/src/iree/hal/buffer.c
+++ b/runtime/src/iree/hal/buffer.c
@@ -296,7 +296,8 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_validate_memory_type(
 IREE_API_EXPORT iree_status_t iree_hal_buffer_validate_access(
     iree_hal_memory_access_t allowed_memory_access,
     iree_hal_memory_access_t required_memory_access) {
-  if (iree_all_bits_set(required_memory_access, IREE_HAL_MEMORY_ACCESS_ANY)) {
+  if (iree_all_bits_set(required_memory_access, IREE_HAL_MEMORY_ACCESS_ANY) ||
+      iree_all_bits_set(allowed_memory_access, IREE_HAL_MEMORY_ACCESS_ANY)) {
     return iree_ok_status();
   }
   if (IREE_UNLIKELY(!iree_any_bit_set(


### PR DESCRIPTION
### TL;DR
Fixed buffer access validation and added device-to-device transfer test for HAL buffers.

### What changed?
- Modified `iree_hal_buffer_validate_access` to allow access when either the allowed memory access is set to `IREE_HAL_MEMORY_ACCESS_ANY`
- Added new test case `Transferd2d` to verify device-to-device buffer transfers with allowed access `IREE_HAL_MEMORY_ACCESS_ANY`
- Introduced overload of `AllocateUninitializedBuffer` helper method to support buffer allocation with custom access flags