### PR TITLE
Expose device info with internal device id of hal device

### DIFF
--- a/runtime/src/iree/hal/device.c
+++ b/runtime/src/iree/hal/device.c
@@ -27,6 +27,12 @@ iree_hal_device_id(iree_hal_device_t* device) {
   return _VTABLE_DISPATCH(device, id)(device);
 }
 
+IREE_API_EXPORT iree_hal_device_info_t
+iree_hal_device_info(iree_hal_device_t* device) {
+  IREE_ASSERT_ARGUMENT(device);
+  return _VTABLE_DISPATCH(device, info)(device);
+}
+
 IREE_API_EXPORT iree_allocator_t
 iree_hal_device_host_allocator(iree_hal_device_t* device) {
   IREE_ASSERT_ARGUMENT(device);

--- a/runtime/src/iree/hal/device.h
+++ b/runtime/src/iree/hal/device.h
@@ -77,6 +77,10 @@ typedef struct iree_hal_device_info_t {
   iree_string_view_t path;
   // Human-readable name of the device as returned by the API.
   iree_string_view_t name;
+  // Device identifier.
+  // This identifier may vary based on the runtime device type; for example, a
+  // Vulkan device may set `vulkan-v1.1` or `vulkan-v1.2-spec1`.
+  iree_string_view_t identifier;
 } iree_hal_device_info_t;
 
 // Defines what information is captured during profiling.
@@ -191,6 +195,10 @@ IREE_API_EXPORT void iree_hal_device_release(iree_hal_device_t* device);
 // Vulkan device may return `vulkan-v1.1` or `vulkan-v1.2-spec1`.
 IREE_API_EXPORT iree_string_view_t
 iree_hal_device_id(iree_hal_device_t* device);
+
+// Returns the device info. (Also see iree_hal_device_id).
+IREE_API_EXPORT iree_hal_device_info_t
+iree_hal_device_info(iree_hal_device_t* device);
 
 // Returns the host allocator used for objects.
 IREE_API_EXPORT iree_allocator_t
@@ -533,6 +541,7 @@ typedef struct iree_hal_device_vtable_t {
   void(IREE_API_PTR* destroy)(iree_hal_device_t* device);
 
   iree_string_view_t(IREE_API_PTR* id)(iree_hal_device_t* device);
+  iree_hal_device_info_t(IREE_API_PTR* info)(iree_hal_device_t* device);
 
   iree_allocator_t(IREE_API_PTR* host_allocator)(iree_hal_device_t* device);
   iree_hal_allocator_t*(IREE_API_PTR* device_allocator)(

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -39,7 +39,7 @@ typedef struct iree_hal_cuda_device_t {
   // Abstract resource used for injecting reference counting and vtable;
   // must be at offset 0.
   iree_hal_resource_t resource;
-  iree_string_view_t identifier;
+  iree_hal_device_info_t info;
 
   // Block pool used for command buffers with a larger block size (as command
   // buffers can contain inlined data uploads).
@@ -408,8 +408,9 @@ static iree_status_t iree_hal_cuda_device_create_internal(
       iree_allocator_malloc(host_allocator, total_size, (void**)&device));
 
   iree_hal_resource_initialize(&iree_hal_cuda_device_vtable, &device->resource);
+  device->info = (struct iree_hal_device_info_t)(.device_id = cu_device);
   iree_string_view_append_to_buffer(
-      identifier, &device->identifier,
+      identifier, &device->info.identifier,
       (char*)device + iree_sizeof_struct(*device));
   iree_arena_block_pool_initialize(params->arena_block_size, host_allocator,
                                    &device->block_pool);
@@ -477,8 +478,8 @@ static iree_status_t iree_hal_cuda_device_create_internal(
 
     status = iree_hal_stream_tracing_context_allocate(
         (iree_hal_stream_tracing_device_interface_t*)tracing_device_interface,
-        device->identifier, device->params.stream_tracing, &device->block_pool,
-        host_allocator, &device->tracing_context);
+        device->info.identifier, device->params.stream_tracing,
+        &device->block_pool, host_allocator, &device->tracing_context);
   }
 
   // Memory pool support is conditional.
@@ -654,7 +655,13 @@ static void iree_hal_cuda_device_destroy(iree_hal_device_t* base_device) {
 static iree_string_view_t iree_hal_cuda_device_id(
     iree_hal_device_t* base_device) {
   iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
-  return device->identifier;
+  return device->info.identifier;
+}
+
+static iree_hal_device_info_t iree_hal_cuda_device_info(
+    iree_hal_device_t* base_device) {
+  iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
+  return device->info;
 }
 
 static iree_allocator_t iree_hal_cuda_device_host_allocator(
@@ -716,7 +723,7 @@ static iree_status_t iree_hal_cuda_device_query_i64(
 
   if (iree_string_view_equal(category, IREE_SV("hal.device.id"))) {
     *out_value =
-        iree_string_view_match_pattern(device->identifier, key) ? 1 : 0;
+        iree_string_view_match_pattern(device->info.identifier, key) ? 1 : 0;
     return iree_ok_status();
   }
 
@@ -1107,6 +1114,7 @@ static iree_status_t iree_hal_cuda_device_profiling_end(
 static const iree_hal_device_vtable_t iree_hal_cuda_device_vtable = {
     .destroy = iree_hal_cuda_device_destroy,
     .id = iree_hal_cuda_device_id,
+    .info = iree_hal_cuda_device_info,
     .host_allocator = iree_hal_cuda_device_host_allocator,
     .device_allocator = iree_hal_cuda_device_allocator,
     .replace_device_allocator = iree_hal_cuda_replace_device_allocator,

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -23,7 +23,7 @@
 
 typedef struct iree_hal_sync_device_t {
   iree_hal_resource_t resource;
-  iree_string_view_t identifier;
+  iree_hal_device_info_t info;
 
   iree_allocator_t host_allocator;
   iree_hal_allocator_t* device_allocator;
@@ -92,7 +92,8 @@ iree_status_t iree_hal_sync_device_create(
     memset(device, 0, total_size);
     iree_hal_resource_initialize(&iree_hal_sync_device_vtable,
                                  &device->resource);
-    iree_string_view_append_to_buffer(identifier, &device->identifier,
+    device->info = (struct iree_hal_device_info_t){};
+    iree_string_view_append_to_buffer(identifier, &device->info.identifier,
                                       (char*)device + struct_size);
     device->host_allocator = host_allocator;
     device->device_allocator = device_allocator;
@@ -142,7 +143,13 @@ static void iree_hal_sync_device_destroy(iree_hal_device_t* base_device) {
 static iree_string_view_t iree_hal_sync_device_id(
     iree_hal_device_t* base_device) {
   iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
-  return device->identifier;
+  return device->info.identifier;
+}
+
+static iree_hal_device_info_t iree_hal_sync_device_info(
+    iree_hal_device_t* base_device) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  return device->info;
 }
 
 static iree_allocator_t iree_hal_sync_device_host_allocator(
@@ -186,7 +193,7 @@ static iree_status_t iree_hal_sync_device_query_i64(
 
   if (iree_string_view_equal(category, IREE_SV("hal.device.id"))) {
     *out_value =
-        iree_string_view_match_pattern(device->identifier, key) ? 1 : 0;
+        iree_string_view_match_pattern(device->info.identifier, key) ? 1 : 0;
     return iree_ok_status();
   }
 
@@ -481,6 +488,7 @@ static iree_status_t iree_hal_sync_device_profiling_end(
 static const iree_hal_device_vtable_t iree_hal_sync_device_vtable = {
     .destroy = iree_hal_sync_device_destroy,
     .id = iree_hal_sync_device_id,
+    .info = iree_hal_sync_device_info,
     .host_allocator = iree_hal_sync_device_host_allocator,
     .device_allocator = iree_hal_sync_device_allocator,
     .replace_device_allocator = iree_hal_sync_replace_device_allocator,

--- a/runtime/src/iree/hal/drivers/local_task/task_device.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.c
@@ -24,7 +24,7 @@
 
 typedef struct iree_hal_task_device_t {
   iree_hal_resource_t resource;
-  iree_string_view_t identifier;
+  iree_hal_device_info_t info;
 
   // Block pool used for small allocations like tasks and submissions.
   iree_arena_block_pool_t small_block_pool;
@@ -109,7 +109,8 @@ iree_status_t iree_hal_task_device_create(
     memset(device, 0, total_size);
     iree_hal_resource_initialize(&iree_hal_task_device_vtable,
                                  &device->resource);
-    iree_string_view_append_to_buffer(identifier, &device->identifier,
+    device->info = (struct iree_hal_device_info_t){};
+    iree_string_view_append_to_buffer(identifier, &device->info.identifier,
                                       (char*)device + struct_size);
     device->host_allocator = host_allocator;
     device->device_allocator = device_allocator;
@@ -134,7 +135,7 @@ iree_status_t iree_hal_task_device_create(
       // TODO(benvanik): add a number to each queue ID.
       iree_hal_queue_affinity_t queue_affinity = 1ull << i;
       iree_hal_task_queue_initialize(
-          device->identifier, queue_affinity, params->queue_scope_flags,
+          device->info.identifier, queue_affinity, params->queue_scope_flags,
           queue_executors[i], &device->small_block_pool,
           &device->large_block_pool, device->device_allocator,
           &device->queues[i]);
@@ -177,7 +178,13 @@ static void iree_hal_task_device_destroy(iree_hal_device_t* base_device) {
 static iree_string_view_t iree_hal_task_device_id(
     iree_hal_device_t* base_device) {
   iree_hal_task_device_t* device = iree_hal_task_device_cast(base_device);
-  return device->identifier;
+  return device->info.identifier;
+}
+
+static iree_hal_device_info_t iree_hal_task_device_info(
+    iree_hal_device_t* base_device) {
+  iree_hal_task_device_t* device = iree_hal_task_device_cast(base_device);
+  return device->info;
 }
 
 static iree_allocator_t iree_hal_task_device_host_allocator(
@@ -232,7 +239,7 @@ static iree_status_t iree_hal_task_device_query_i64(
 
   if (iree_string_view_equal(category, IREE_SV("hal.device.id"))) {
     *out_value =
-        iree_string_view_match_pattern(device->identifier, key) ? 1 : 0;
+        iree_string_view_match_pattern(device->info.identifier, key) ? 1 : 0;
     return iree_ok_status();
   }
 
@@ -516,6 +523,7 @@ static iree_status_t iree_hal_task_device_profiling_end(
 static const iree_hal_device_vtable_t iree_hal_task_device_vtable = {
     .destroy = iree_hal_task_device_destroy,
     .id = iree_hal_task_device_id,
+    .info = iree_hal_task_device_info,
     .host_allocator = iree_hal_task_device_host_allocator,
     .device_allocator = iree_hal_task_device_allocator,
     .replace_device_allocator = iree_hal_task_replace_device_allocator,

--- a/runtime/src/iree/hal/drivers/metal/metal_device.m
+++ b/runtime/src/iree/hal/drivers/metal/metal_device.m
@@ -25,7 +25,7 @@ typedef struct iree_hal_metal_device_t {
   // Abstract resource used for injecting reference counting and vtable; must be at offset 0.
   iree_hal_resource_t resource;
 
-  iree_string_view_t identifier;
+  iree_hal_device_info_t info;
 
   // Block pool used for command buffers with a larger block size (as command buffers can
   // contain inlined data uploads).
@@ -98,6 +98,7 @@ static iree_status_t iree_hal_metal_device_create_internal(
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(host_allocator, total_size, (void**)&device));
 
   iree_hal_resource_initialize(&iree_hal_metal_device_vtable, &device->resource);
+  device->info = (struct iree_hal_device_info_t){};
   iree_string_view_append_to_buffer(identifier, &device->identifier,
                                     (char*)device + iree_sizeof_struct(*device));
   iree_arena_block_pool_initialize(params->arena_block_size, host_allocator, &device->block_pool);
@@ -186,7 +187,12 @@ static void iree_hal_metal_device_destroy(iree_hal_device_t* base_device) {
 
 static iree_string_view_t iree_hal_metal_device_id(iree_hal_device_t* base_device) {
   iree_hal_metal_device_t* device = iree_hal_metal_device_cast(base_device);
-  return device->identifier;
+  return device->info.identifier;
+}
+
+static iree_hal_device_info_t iree_hal_metal_device_info(iree_hal_device_t* base_device) {
+  iree_hal_metal_device_t* device = iree_hal_metal_device_cast(base_device);
+  return device->info;
 }
 
 static iree_allocator_t iree_hal_metal_device_host_allocator(iree_hal_device_t* base_device) {
@@ -598,6 +604,7 @@ static iree_status_t iree_hal_metal_device_profiling_end(iree_hal_device_t* base
 static const iree_hal_device_vtable_t iree_hal_metal_device_vtable = {
     .destroy = iree_hal_metal_device_destroy,
     .id = iree_hal_metal_device_id,
+    .info = iree_hal_metal_device_info,
     .host_allocator = iree_hal_metal_device_host_allocator,
     .device_allocator = iree_hal_metal_device_allocator,
     .replace_device_allocator = iree_hal_metal_replace_device_allocator,

--- a/runtime/src/iree/hal/drivers/vulkan/extensibility_util.h
+++ b/runtime/src/iree/hal/drivers/vulkan/extensibility_util.h
@@ -169,6 +169,8 @@ typedef struct iree_hal_vulkan_device_properties_t {
 
   // Device limits.
   iree_hal_vulkan_device_limits_t limits;
+  // Device info.
+  iree_hal_device_info_t device_info;
 } iree_hal_vulkan_iree_hal_vulkan_device_properties_t;
 
 #endif  // IREE_HAL_DRIVERS_VULKAN_EXTENSIBILITY_UTIL_H_

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -488,7 +488,6 @@ static iree_status_t iree_hal_vulkan_build_queue_sets(
 
 typedef struct iree_hal_vulkan_device_t {
   iree_hal_resource_t resource;
-  iree_string_view_t identifier;
 
   // Optional driver that owns the instance. We retain it for our lifetime to
   // ensure the instance remains valid.
@@ -719,12 +718,14 @@ static iree_status_t iree_hal_vulkan_device_create_internal(
   device->driver = driver;
   iree_hal_driver_retain(device->driver);
   uint8_t* buffer_ptr = (uint8_t*)device + sizeof(*device);
+  device->device_properties = *device_properties;
   buffer_ptr += iree_string_view_append_to_buffer(
-      identifier, &device->identifier, (char*)buffer_ptr);
+      identifier, &device->device_properties.device_info.identifier,
+      (char*)buffer_ptr);
   device->flags = options->flags;
 
   device->device_extensions = *device_extensions;
-  device->device_properties = *device_properties;
+
   device->instance = instance;
   device->physical_device = physical_device;
   device->logical_device = logical_device;
@@ -919,6 +920,9 @@ static iree_status_t iree_hal_vulkan_query_device_properties(
   physical_device_properties.sType =
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
   physical_device_properties.pNext = NULL;
+
+  out_properties->device_info = iree_hal_device_info_t{
+      .device_id = physical_device_properties.properties.deviceID};
 
   // + Subgroup properties.
   VkPhysicalDeviceSubgroupProperties subgroup_properties;
@@ -1389,7 +1393,13 @@ IREE_API_EXPORT iree_status_t iree_hal_vulkan_wrap_device(
 static iree_string_view_t iree_hal_vulkan_device_id(
     iree_hal_device_t* base_device) {
   iree_hal_vulkan_device_t* device = iree_hal_vulkan_device_cast(base_device);
-  return device->identifier;
+  return device->device_properties.device_info.identifier;
+}
+
+static iree_hal_device_info_t iree_hal_vulkan_device_info(
+    iree_hal_device_t* base_device) {
+  iree_hal_vulkan_device_t* device = iree_hal_vulkan_device_cast(base_device);
+  return device->device_properties.device_info;
 }
 
 static iree_allocator_t iree_hal_vulkan_device_host_allocator(
@@ -1434,8 +1444,10 @@ static iree_status_t iree_hal_vulkan_device_query_i64(
   *out_value = 0;
 
   if (iree_string_view_equal(category, IREE_SV("hal.device.id"))) {
-    *out_value =
-        iree_string_view_match_pattern(device->identifier, key) ? 1 : 0;
+    *out_value = iree_string_view_match_pattern(
+                     device->device_properties.device_info.identifier, key)
+                     ? 1
+                     : 0;
     return iree_ok_status();
   }
 
@@ -1664,9 +1676,9 @@ static iree_status_t iree_hal_vulkan_device_queue_read(
   // TODO: expose streaming chunk count/size options.
   iree_status_t loop_status = iree_ok_status();
   iree_hal_file_transfer_options_t options = {
-      /*.loop=*/iree_loop_inline(&loop_status),
-      /*.chunk_count=*/IREE_HAL_FILE_TRANSFER_CHUNK_COUNT_DEFAULT,
-      /*.chunk_size=*/IREE_HAL_FILE_TRANSFER_CHUNK_SIZE_DEFAULT,
+      .loop = iree_loop_inline(&loop_status),
+      .chunk_count = IREE_HAL_FILE_TRANSFER_CHUNK_COUNT_DEFAULT,
+      .chunk_size = IREE_HAL_FILE_TRANSFER_CHUNK_SIZE_DEFAULT,
   };
   IREE_RETURN_IF_ERROR(iree_hal_device_queue_read_streaming(
       base_device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
@@ -1685,9 +1697,9 @@ static iree_status_t iree_hal_vulkan_device_queue_write(
   // TODO: expose streaming chunk count/size options.
   iree_status_t loop_status = iree_ok_status();
   iree_hal_file_transfer_options_t options = {
-      /*.loop=*/iree_loop_inline(&loop_status),
-      /*.chunk_count=*/IREE_HAL_FILE_TRANSFER_CHUNK_COUNT_DEFAULT,
-      /*.chunk_size=*/IREE_HAL_FILE_TRANSFER_CHUNK_SIZE_DEFAULT,
+      .loop = iree_loop_inline(&loop_status),
+      .chunk_count = IREE_HAL_FILE_TRANSFER_CHUNK_COUNT_DEFAULT,
+      .chunk_size = IREE_HAL_FILE_TRANSFER_CHUNK_SIZE_DEFAULT,
   };
   IREE_RETURN_IF_ERROR(iree_hal_device_queue_write_streaming(
       base_device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
@@ -1740,12 +1752,12 @@ static iree_status_t iree_hal_vulkan_device_queue_execute(
 
   if (iree_status_is_ok(status)) {
     iree_hal_vulkan_submission_batch_t batch = {
-        /*.wait_semaphores=*/wait_semaphore_list,
-        /*.command_buffer_count=*/
-        (iree_host_size_t)(translated_command_buffer ? 1 : 0),
-        /*.command_buffers=*/
-        translated_command_buffer ? &translated_command_buffer : NULL,
-        /*.signal_semaphores=*/signal_semaphore_list,
+        .wait_semaphores = wait_semaphore_list,
+        .command_buffer_count =
+            (iree_host_size_t)(translated_command_buffer ? 1 : 0),
+        .command_buffers =
+            translated_command_buffer ? &translated_command_buffer : NULL,
+        .signal_semaphores = signal_semaphore_list,
     };
     status = queue->Submit(1, &batch);
   }
@@ -1867,35 +1879,34 @@ static iree_status_t iree_hal_vulkan_device_profiling_end(
 
 namespace {
 const iree_hal_device_vtable_t iree_hal_vulkan_device_vtable = {
-    /*.destroy=*/iree_hal_vulkan_device_destroy,
-    /*.id=*/iree_hal_vulkan_device_id,
-    /*.host_allocator=*/iree_hal_vulkan_device_host_allocator,
-    /*.device_allocator=*/iree_hal_vulkan_device_allocator,
-    /*.replace_device_allocator=*/iree_hal_vulkan_replace_device_allocator,
-    /*.replace_channel_provider=*/iree_hal_vulkan_replace_channel_provider,
-    /*.trim=*/iree_hal_vulkan_device_trim,
-    /*.query_i64=*/iree_hal_vulkan_device_query_i64,
-    /*.create_channel=*/iree_hal_vulkan_device_create_channel,
-    /*.create_command_buffer=*/iree_hal_vulkan_device_create_command_buffer,
-    /*.create_event=*/iree_hal_vulkan_device_create_event,
-    /*.create_executable_cache=*/
-    iree_hal_vulkan_device_create_executable_cache,
-    /*.import_file=*/iree_hal_vulkan_device_import_file,
-    /*.create_semaphore=*/iree_hal_vulkan_device_create_semaphore,
-    /*.query_semaphore_compatibility=*/
-    iree_hal_vulkan_device_query_semaphore_compatibility,
-    /*.queue_alloca=*/iree_hal_vulkan_device_queue_alloca,
-    /*.queue_dealloca=*/iree_hal_vulkan_device_queue_dealloca,
-    /*.queue_fill=*/iree_hal_device_queue_emulated_fill,
-    /*.queue_update=*/iree_hal_device_queue_emulated_update,
-    /*.queue_copy=*/iree_hal_device_queue_emulated_copy,
-    /*.queue_read=*/iree_hal_vulkan_device_queue_read,
-    /*.queue_write=*/iree_hal_vulkan_device_queue_write,
-    /*.queue_execute=*/iree_hal_vulkan_device_queue_execute,
-    /*.queue_flush=*/iree_hal_vulkan_device_queue_flush,
-    /*.wait_semaphores=*/iree_hal_vulkan_device_wait_semaphores,
-    /*.profiling_begin=*/iree_hal_vulkan_device_profiling_begin,
-    /*.profiling_flush=*/iree_hal_vulkan_device_profiling_flush,
-    /*.profiling_end=*/iree_hal_vulkan_device_profiling_end,
+    .destroy = iree_hal_vulkan_device_destroy,
+    .id = iree_hal_vulkan_device_id,
+    .host_allocator = iree_hal_vulkan_device_host_allocator,
+    .device_allocator = iree_hal_vulkan_device_allocator,
+    .replace_device_allocator = iree_hal_vulkan_replace_device_allocator,
+    .replace_channel_provider = iree_hal_vulkan_replace_channel_provider,
+    .trim = iree_hal_vulkan_device_trim,
+    .query_i64 = iree_hal_vulkan_device_query_i64,
+    .create_channel = iree_hal_vulkan_device_create_channel,
+    .create_command_buffer = iree_hal_vulkan_device_create_command_buffer,
+    .create_event = iree_hal_vulkan_device_create_event,
+    .create_executable_cache = iree_hal_vulkan_device_create_executable_cache,
+    .import_file = iree_hal_vulkan_device_import_file,
+    .create_semaphore = iree_hal_vulkan_device_create_semaphore,
+    .query_semaphore_compatibility =
+        iree_hal_vulkan_device_query_semaphore_compatibility,
+    .queue_alloca = iree_hal_vulkan_device_queue_alloca,
+    .queue_dealloca = iree_hal_vulkan_device_queue_dealloca,
+    .queue_fill = iree_hal_device_queue_emulated_fill,
+    .queue_update = iree_hal_device_queue_emulated_update,
+    .queue_copy = iree_hal_device_queue_emulated_copy,
+    .queue_read = iree_hal_vulkan_device_queue_read,
+    .queue_write = iree_hal_vulkan_device_queue_write,
+    .queue_execute = iree_hal_vulkan_device_queue_execute,
+    .queue_flush = iree_hal_vulkan_device_queue_flush,
+    .wait_semaphores = iree_hal_vulkan_device_wait_semaphores,
+    .profiling_begin = iree_hal_vulkan_device_profiling_begin,
+    .profiling_flush = iree_hal_vulkan_device_profiling_flush,
+    .profiling_end = iree_hal_vulkan_device_profiling_end,
 };
 }  // namespace


### PR DESCRIPTION
### TL;DR

Adds device info struct and API to expose additional device metadata like device IDs and identifiers.

### What changed?

- Added identifier to `iree_hal_device_info_t` struct
->  Consolidated device identifier handling into the device info struct
- Added `iree_hal_device_info()` API to query device information
- Updated all HAL device implementations (CUDA, HIP, Metal, Vulkan, etc.) to populate and return device info


### Why make this change?

The device id is needed for dlpack export