### PR TITLE
refactor(iree): set CPU stack allocation limit as an LLVM target option

### DIFF
--- a/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.cpp
+++ b/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.cpp
@@ -139,6 +139,7 @@ void LLVMTarget::storeToConfigAttrs(MLIRContext *context,
   if (vectorWidthInBytes != DEFAULT_VECTOR_WIDTH_IN_BYTES) {
     addInt64("native_vector_size", vectorWidthInBytes);
   }
+  addInt64("max_stack_allocation_size", maxStackAllocSizeInBytes);
   if (linkEmbedded != DEFAULT_LINK_EMBEDDED) {
     addBool("link_embedded", linkEmbedded);
   }
@@ -581,6 +582,11 @@ void LLVMCPUTargetCLOptions::bindOptions(OptionsBinder &binder) {
                        targetVectorWidthInBytes, llvm::cl::cat(category),
                        llvm::cl::desc("Overrides the native vector register "
                                       "width (in bytes) of the target."));
+  binder.opt<unsigned>(
+      "iree-llvmcpu-stack-allocation-limit", targetMaxStackAllocSizeInBytes,
+      llvm::cl::cat(category),
+      llvm::cl::desc(
+          "Maximum allowed stack allocation size for LLVM CPU in bytes"));
   binder.opt<std::string>(
       "iree-llvmcpu-enable-ukernels", enableUkernels, llvm::cl::cat(category),
       llvm::cl::desc("Enables ukernels in the llvmcpu backend. May be "
@@ -634,6 +640,7 @@ LLVMTargetOptions LLVMCPUTargetCLOptions::getTargetOptions() {
   target.llvmTargetOptions.FloatABIType = targetFloatABI;
   target.dataLayout = targetDataLayout;
   target.vectorWidthInBytes = targetVectorWidthInBytes;
+  target.maxStackAllocSizeInBytes = targetMaxStackAllocSizeInBytes;
   target.ukernels = enableUkernels;
   target.linkUkernelBitcode = linkUKernelBitcode;
 

--- a/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.h
+++ b/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.h
@@ -33,6 +33,7 @@ enum class SanitizerKind {
 struct LLVMTarget {
   static constexpr const char *DEFAULT_DATA_LAYOUT = "";
   static constexpr int64_t DEFAULT_VECTOR_WIDTH_IN_BYTES = 0;
+  static constexpr unsigned DEFAULT_MAX_STACK_ALLOC_SIZE_IN_BYTES = 32678;
   static constexpr bool DEFAULT_LINK_EMBEDDED = true;
   static constexpr bool DEFAULT_DEBUG_SYMBOLS = true;
   static constexpr SanitizerKind DEFAULT_SANITIZER_KIND = SanitizerKind::kNone;
@@ -88,6 +89,7 @@ struct LLVMTarget {
   std::string dataLayout = DEFAULT_DATA_LAYOUT;
   // Overrides the vector width (in bytes) of the target.
   int64_t vectorWidthInBytes = DEFAULT_VECTOR_WIDTH_IN_BYTES;
+  unsigned maxStackAllocSizeInBytes = DEFAULT_MAX_STACK_ALLOC_SIZE_IN_BYTES;
 
   llvm::PipelineTuningOptions pipelineTuningOptions;
   // Optimization level to be used by the LLVM optimizer (middle-end).
@@ -194,6 +196,8 @@ struct LLVMCPUTargetCLOptions {
   llvm::FloatABI::ABIType targetFloatABI = LLVMTarget::DEFAULT_FLOAT_ABI;
   std::string targetDataLayout = LLVMTarget::DEFAULT_DATA_LAYOUT;
   unsigned targetVectorWidthInBytes = LLVMTarget::DEFAULT_VECTOR_WIDTH_IN_BYTES;
+  unsigned targetMaxStackAllocSizeInBytes =
+      LLVMTarget::DEFAULT_MAX_STACK_ALLOC_SIZE_IN_BYTES;
   std::string enableUkernels = LLVMTarget::DEFAULT_ENABLE_UKERNELS;
   bool linkUKernelBitcode = LLVMTarget::DEFAULT_LINK_UKERNEL_BITCODE;
   bool listTargets; // Ignored - used with llvm::cl::ValueDisallowed.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_target_device_attributes.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_target_device_attributes.mlir
@@ -1,0 +1,33 @@
+// This test aims to check default HAL properties for LLVM CPU target, and
+// whether CLI options modify the values correctly.
+
+module {
+  util.func public @foo(%arg0: tensor<?xf32>) -> tensor<?xf32> {
+    util.return %arg0 : tensor<?xf32>
+  }
+}
+
+// TODO: Expand the test for more CLI configurations, e.g. different target triples
+
+// RUN: iree-compile --compile-to=preprocessing --iree-hal-target-backends=llvm-cpu --iree-llvmcpu-target-triple=x86_64-linux-gnu %s \
+// RUN: | FileCheck %s --check-prefix=CHECK-X86-DEFAULT
+//
+// CHECK-X86-DEFAULT: module attributes {stream.affinity.default = #hal.device.affinity<@__device_0>} {
+// CHECK-X86-DEFAULT-NEXT: util.global private @__device_0 = #hal.device.target<"local",
+// CHECK-X86-DEFAULT-SAME: [#hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu = "", cpu_features = ""
+// CHECK-X86-DEFAULT-SAME: max_stack_allocation_size = 32678 : i64
+// CHECK-X86-DEFAULT-SAME: native_vector_size = 16 : i64
+// CHECK-X86-DEFAULT-SAME: target_triple = "x86_64-unknown-unknown-eabi-elf"
+// CHECK-X86-DEFAULT-SAME: }>]> : !hal.device
+
+// RUN: iree-compile --compile-to=preprocessing --iree-hal-target-backends=llvm-cpu --iree-llvmcpu-target-triple=x86_64-linux-gnu %s \
+// RUN:              --iree-llvmcpu-stack-allocation-limit=65536 \
+// RUN: | FileCheck %s --check-prefix=CHECK-STACK-VALUE
+//
+// CHECK-STACK-VALUE: module attributes {stream.affinity.default = #hal.device.affinity<@__device_0>} {
+// CHECK-STACK-VALUE-NEXT: util.global private @__device_0 = #hal.device.target<"local",
+// CHECK-STACK-VALUE-SAME: [#hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu = "", cpu_features = ""
+//
+// CHECK-STACK-VALUE-SAME: max_stack_allocation_size = 65536 : i64
+//
+// CHECK-STACK-VALUE-SAME: }>]> : !hal.device

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_target_device_attributes.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_target_device_attributes.mlir
@@ -1,12 +1,6 @@
 // This test aims to check default HAL properties for LLVM CPU target, and
 // whether CLI options modify the values correctly.
 
-module {
-  util.func public @foo(%arg0: tensor<?xf32>) -> tensor<?xf32> {
-    util.return %arg0 : tensor<?xf32>
-  }
-}
-
 // TODO: Expand the test for more CLI configurations, e.g. different target triples
 
 // RUN: iree-compile --compile-to=preprocessing --iree-hal-target-backends=llvm-cpu --iree-llvmcpu-target-triple=x86_64-linux-gnu %s \
@@ -31,3 +25,9 @@ module {
 // CHECK-STACK-VALUE-SAME: max_stack_allocation_size = 65536 : i64
 //
 // CHECK-STACK-VALUE-SAME: }>]> : !hal.device
+
+module {
+  util.func public @foo(%arg0: tensor<?xf32>) -> tensor<?xf32> {
+    util.return %arg0 : tensor<?xf32>
+  }
+}


### PR DESCRIPTION
In order to systemically address `exceeded stack allocation limit` failures for the CPU pipeline, we first need a way of conveying the limit itself to the whole pipeline. Therefore, create a new context-wide attribute, as well as a bound CLI option to replace the one specific to `LLVMCPUCheckIRBeforeLLVMConversionPass`.

A further direction for improvement would be unit-testing all the target properties & corresponding CLI options on the basis of this PR.