### PR TITLE
fix(iree): fix default value of CPU stack allocation limit

### DIFF
--- a/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.h
+++ b/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.h
@@ -33,7 +33,7 @@ enum class SanitizerKind {
 struct LLVMTarget {
   static constexpr const char *DEFAULT_DATA_LAYOUT = "";
   static constexpr int64_t DEFAULT_VECTOR_WIDTH_IN_BYTES = 0;
-  static constexpr unsigned DEFAULT_MAX_STACK_ALLOC_SIZE_IN_BYTES = 32678;
+  static constexpr unsigned DEFAULT_MAX_STACK_ALLOC_SIZE_IN_BYTES = 32768;
   static constexpr bool DEFAULT_LINK_EMBEDDED = true;
   static constexpr bool DEFAULT_DEBUG_SYMBOLS = true;
   static constexpr SanitizerKind DEFAULT_SANITIZER_KIND = SanitizerKind::kNone;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_target_device_attributes.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_target_device_attributes.mlir
@@ -9,7 +9,7 @@
 // CHECK-X86-DEFAULT: module attributes {stream.affinity.default = #hal.device.affinity<@__device_0>} {
 // CHECK-X86-DEFAULT-NEXT: util.global private @__device_0 = #hal.device.target<"local",
 // CHECK-X86-DEFAULT-SAME: [#hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu = "", cpu_features = ""
-// CHECK-X86-DEFAULT-SAME: max_stack_allocation_size = 32678 : i64
+// CHECK-X86-DEFAULT-SAME: max_stack_allocation_size = 32768 : i64
 // CHECK-X86-DEFAULT-SAME: native_vector_size = 16 : i64
 // CHECK-X86-DEFAULT-SAME: target_triple = "x86_64-unknown-unknown-eabi-elf"
 // CHECK-X86-DEFAULT-SAME: }>]> : !hal.device


### PR DESCRIPTION
Follow up on commit bb8d9b9.