### PR TITLE
feat(iree): relax input/output element type checks for linalg_ext.scan

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -410,9 +410,9 @@ LogicalResult ScanOp::verify() {
   auto outputType = cast<ShapedType>(getOutput().getType());
   ArrayRef<int64_t> inputShapes = inputType.getShape();
   ArrayRef<int64_t> outputShapes = outputType.getShape();
-  if (accumulatorType.getElementType() != inputType.getElementType()) {
+  if (accumulatorType.getElementType() != outputType.getElementType()) {
     return op->emitOpError(
-        "expected input/accumulator element types to be identical");
+        "expected output/accumulator element types to be identical");
   }
   ArrayRef<int64_t> accumulatorShape = accumulatorType.getShape();
   int64_t accumulatorRank = accumulatorType.getRank();
@@ -433,10 +433,6 @@ LogicalResult ScanOp::verify() {
                             std::get<0>(s) != std::get<1>(s);
                    })) {
     return op->emitOpError("incompatible input/accumulator shapes");
-  }
-  if (inputType.getElementType() != outputType.getElementType()) {
-    return op->emitOpError(
-        "expected input/output element types to be identical");
   }
   if (inputShapes.size() != outputShapes.size()) {
     return op->emitOpError("expected input/output to have identical ranks");

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -384,6 +384,9 @@ def IREELinalgExt_ScanOp : IREELinalgExt_Op<"scan",
   let summary = "Scan operator";
   let description = [{
     Computes the inclusive/exclusive scan along a given dimension.
+
+    Numeric casting is allowed on the input operand, promoting it to the same
+    underlying element type as the output and accumulator.
   }];
 
   let arguments = (ins Variadic<AnyShaped>:$inputs,


### PR DESCRIPTION
Relax the rules on element type coherence between LinalgExt ScanOp's input and output tensors. Per semantics of the ScanOp, each reduction iteration operates on the preceding output element and also indexes into the input data.

The aim is to eventually unblock fusion of elementwise type-casting producers directly into the body of the scan. Such cases often stem from `torch.cumsum` / `stablehlo.reduce_window` patterns.

To facilitate differing input/output dtypes, we require that the scalar block's 1st argument type match the output dtype (as it's already been casted to the target dtype on the previous iteration), and the 2nd arg type match the input dtype. For the inclusive scan case, `output[0] = input[0]` is facilitated through a "default" signed numerical cast during scalar implementation emission.