### PR TITLE
Re-apply commit "[Codegen] Block dyn dims of parallel linalg.generic ops"

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
@@ -275,6 +275,10 @@ static LogicalResult
 blockDynamicDimensions(RewriterBase &rewriter,
                        const TensorDynamicDimAnalysis &dynamicDimAnalysis,
                        linalg::LinalgOp linalgOp) {
+  if (isa<linalg::GenericOp>(linalgOp) && linalgOp.isAllParallelLoops()) {
+    return blockDynamicDimensionsOfAllTensorOperandsAndResults(
+        rewriter, dynamicDimAnalysis, linalgOp);
+  }
   if (linalg::isaContractionOpInterface(linalgOp)) {
     return blockDynamicDimensionsOfAllTensorOperandsAndResults(
         rewriter, dynamicDimAnalysis, linalgOp);

--- a/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
@@ -253,3 +253,58 @@ func.func @multiple_dynamic_dims(%arg0 : index, %arg1 : index) -> tensor<?x?x409
 //  CHECK-SAME:       outs(%[[INIT]] :
 //       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[MATMUL]]
 //       CHECK:   return %[[COLLAPSE]]
+
+// -----
+
+func.func @block_elementwise(%arg0 : tensor<?xf16>, %dim : index)
+    -> tensor<?xf16> {
+  %0 = util.assume.int %dim<udiv = 1024> : index
+  %cst = arith.constant 0.2 : f16
+  %init = tensor.empty(%0) : tensor<?xf16>
+  %2 = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>,
+                       affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%arg0 : tensor<?xf16>) outs(%init : tensor<?xf16>) {
+    ^bb0(%in : f16, %out : f16):
+      %3 = arith.addf %in, %cst : f16
+      linalg.yield %3 : f16
+  } -> tensor<?xf16>
+  return %2 : tensor<?xf16>
+}
+// CHECK-LABEL: func @block_elementwise(
+//       CHECK:   %[[ELEM:.+]] = linalg.generic
+//       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[ELEM]]
+//  CHECK-SAME:     tensor<?x1024xf16> into tensor<?xf16>
+//       CHECK:   return %[[COLLAPSE]] : tensor<?xf16>
+
+// -----
+
+// Check that there are no SSA violations during blocking
+func.func @check_ssa_violation(%dim : index,
+    %lhs : tensor<?xf32>, %rhs : tensor<?xf32>) -> tensor<?xf32> {
+  %c4 = arith.constant 4 : index
+  %0 = arith.muli %dim, %c4 overflow<nsw> : index
+  %1 = tensor.empty(%0) : tensor<?xf32>
+  %2 = linalg.generic {
+        indexing_maps = [affine_map<(d0) -> (d0)>,
+                         affine_map<(d0) -> (d0)>,
+                         affine_map<(d0) -> (d0)>],
+        iterator_types = ["parallel"]}
+        ins(%lhs, %rhs : tensor<?xf32>, tensor<?xf32>)
+        outs(%1 : tensor<?xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %33 = arith.addf %in, %in_0 : f32
+    linalg.yield %33 : f32
+  } -> tensor<?xf32>
+  return %2 : tensor<?xf32>
+}
+// CHECK-LABEL: func @check_ssa_violation
+//  CHECK-SAME:     %[[LHS:[a-zA-Z0-9]+]]: tensor<?xf32>
+//  CHECK-SAME:     %[[RHS:[a-zA-Z0-9]+]]: tensor<?xf32>
+//   CHECK-DAG:   %[[EXPANDED0:.+]] = tensor.expand_shape %[[LHS]]
+//   CHECK-DAG:   %[[EXPANDED1:.+]] = tensor.expand_shape %[[RHS]]
+//       CHECK:   %[[GENERIC:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[EXPANDED0]], %[[EXPANDED1]] :
+//       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[GENERIC]]
+//       CHECK:   return %[[COLLAPSE]]

--- a/compiler/src/iree/compiler/DispatchCreation/test/attention_fuse_by_expansion.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/attention_fuse_by_expansion.mlir
@@ -583,14 +583,13 @@ util.func @scatter_collapse_original_partial(%arg0: tensor<?x1x32x8x128xf16>, %a
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]:
 //  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]:
 //  CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]:
-//   CHECK-DAG:   %[[UPDATES:.+]] = tensor.expand_shape %[[ARG0]] {{.*}} tensor<?x1x32x8x128xf16> into tensor<?x1x2x16x4x2x64x2xf16>
-// TODO(IanWood1): fix this so the collapse folds with the expand
-//   CHECK-DAG:   %[[ORIGINAL:.+]] = tensor.expand_shape {{.*}} tensor<?x32x8x128xf16> into tensor<?x2x16x4x2x64x2xf16>
+//   CHECK-DAG:   %[[EXPAND:.+]] = tensor.expand_shape %[[ARG0]] {{.*}} tensor<?x1x32x8x128xf16> into tensor<?x1x2x16x4x2x64x2xf16>
+//   CHECK-DAG:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[ARG2]] {{.*}} tensor<5x?x2x16x4x2x64x2xf16> into tensor<?x2x16x4x2x64x2xf16>
 //       CHECK:   %[[SCATTER:.+]] = iree_linalg_ext.scatter
-//  CHECK-SAME:       ins(%[[UPDATES]], %[[ARG1]]
-//  CHECK-SAME:       outs(%[[ORIGINAL]]
-//       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[SCATTER]]
-//       CHECK:   util.return %[[COLLAPSE]]
+//  CHECK-SAME:       ins(%[[EXPAND]], %[[ARG1]]
+//  CHECK-SAME:       outs(%[[COLLAPSE]]
+//       CHECK:   %[[RES_COLLAPSE:.+]] = tensor.collapse_shape %[[SCATTER]]
+//       CHECK:   util.return %[[RES_COLLAPSE]]
 
 // -----
 


### PR DESCRIPTION
This reverts commit 3bd685e7e858c524fee9b3c513c47be3f4e0227a, re-applying commit
d96d142fab6f059b44be38fb6ae1ea776097dd9a. To facilitate that, required changes
from LLVM are also integrated, along with an appropriate LIT test update.