### PR TITLE
Revert "workaround(iree): disable WG-context global writes verification for LLVMCPU"

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -847,10 +847,7 @@ void buildLLVMCPUCodegenPassPipeline(OpPassManager &variantPassManager,
     modulePassManager.addPass(createLowerExecutableUsingTransformDialectPass());
     FunctionLikeNest(modulePassManager)
         .addPass(createLLVMCPULowerExecutableTargetPass)
-        // TODO (ROO-321): Analyze the issue with bare linalg.fill operations
-        // and re-enable the verification
-        // .addPass(createVerifyWorkgroupDistributionPass)
-        ;
+        .addPass(createVerifyWorkgroupDistributionPass);
   }
 
   variantPassManager.addPass(createReconcileTranslationInfoPass());


### PR DESCRIPTION
This reverts commit 0bc671eeec7935bbb20dd71cd99f2c5c7b8284f3.