### PR TITLE
fix: Missing device info ptr in vulkan hal device vtable

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -1883,6 +1883,7 @@ namespace {
 const iree_hal_device_vtable_t iree_hal_vulkan_device_vtable = {
     .destroy = iree_hal_vulkan_device_destroy,
     .id = iree_hal_vulkan_device_id,
+    .info = iree_hal_vulkan_device_info,
     .host_allocator = iree_hal_vulkan_device_host_allocator,
     .device_allocator = iree_hal_vulkan_device_allocator,
     .replace_device_allocator = iree_hal_vulkan_replace_device_allocator,


### PR DESCRIPTION
Original commit of feature: fd669498b51e02f870de41c61ef84dfa2c2d47f6