### PR TITLE
feat(TOSA); add disable profile validation option

### DIFF
--- a/compiler/plugins/input/TOSA/InputConversion/Passes.h
+++ b/compiler/plugins/input/TOSA/InputConversion/Passes.h
@@ -10,6 +10,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassOptions.h"
 
 namespace mlir::iree_compiler {
 
@@ -17,8 +18,18 @@ namespace mlir::iree_compiler {
 // Pipelines
 //===----------------------------------------------------------------------===//
 
+struct TosaConversionPassOptions
+    : public PassPipelineOptions<TosaConversionPassOptions> {
+  PassOptions::Option<bool> disableProfileValidation{
+      *this, "disable-profile-validation",
+      llvm::cl::desc("Whether to disable the validation profiles for pro_int "
+                     "and pro_fp for TOSA."),
+      llvm::cl::init(false)};
+};
+
 // Performs input legalization for specific combination of input dialects.
-void buildTOSAInputConversionPassPipeline(OpPassManager &passManager);
+void buildTOSAInputConversionPassPipeline(
+    OpPassManager &passManager, const TosaConversionPassOptions &options);
 
 void registerTOSAConversionPassPipeline();
 

--- a/compiler/plugins/input/TOSA/PluginRegistration.cpp
+++ b/compiler/plugins/input/TOSA/PluginRegistration.cpp
@@ -40,7 +40,12 @@ struct TOSASession
   bool extendCustomInputConversionPassPipeline(
       OpPassManager &passManager, std::string_view typeMnemonic) override {
     if (typeMnemonic == "tosa") {
-      buildTOSAInputConversionPassPipeline(passManager);
+      // WARNING: the conversion pass now has options whether to execute the
+      // profile validation for the TOSA specification. In our use-case we
+      // do not use the plugin, but the pass pipeline itself in a custom
+      // pipeline. Therefore, we add the default options to satisfy the build.
+      TosaConversionPassOptions options;
+      buildTOSAInputConversionPassPipeline(passManager, options);
       return true;
     }
 


### PR DESCRIPTION
For our TOSA lowering, we do not need to validate against the
TOSA spec. Adding this option allows us to skip the valdiation
of the operation.