### PR TITLE
bugfix(build): fixes the runtime build issue roo-447

### DIFF
--- a/runtime/bindings/python/BUILD.bazel
+++ b/runtime/bindings/python/BUILD.bazel
@@ -19,7 +19,6 @@ cc_library(
         "@pypi_numpy//:site-packages/numpy/_core/include/numpy/halffloat.h",
         "@pypi_numpy//:site-packages/numpy/_core/include/numpy/ndarrayobject.h",
         "@pypi_numpy//:site-packages/numpy/_core/include/numpy/ndarraytypes.h",
-        "@pypi_numpy//:site-packages/numpy/_core/include/numpy/npy_1_7_deprecated_api.h",
         "@pypi_numpy//:site-packages/numpy/_core/include/numpy/npy_2_compat.h",
         "@pypi_numpy//:site-packages/numpy/_core/include/numpy/npy_2_complexcompat.h",
         "@pypi_numpy//:site-packages/numpy/_core/include/numpy/npy_3kcompat.h",


### PR DESCRIPTION
This one actually fixes the build issue that I encountered. Other issue we have is that our numpy version is not pinned and set to `>=2.0.0` which is fine, but I guess that was the root cause of the problem in the first place. I know that also taking care of bumping numpy versions etc. would also be a burden on the developer and is sort of unnecessary since it's not really like `torch` or `transformers` that _explicitly_ affect us, but still wanted to pull attention towards it as well.

The version I have on my local bazel cache in the workspace that I was using is `2.2.6` whereas the new workspace had `2.3.0`, which I think deleted those headers btw. The local one still works with the cached one, so you might actually need a clean workspace or clean your bazel cache to reproduce this.

Looking back into [the release notes](https://numpy.org/devdocs/release/2.3.0-notes.html#expired-deprecations) it looks like it is indeed removed.