### PR TITLE
feat(codegen): use control function to prevent fusion-inhibiting folding patterns

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -19,10 +19,12 @@
 #include "iree/compiler/Dialect/HAL/Analysis/DeviceAnalysis.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "iree/compiler/Dialect/Stream/Analysis/Affinity.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Interfaces/TilingInterface.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/CSE.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -143,7 +145,29 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
     linalg::FillOp::getCanonicalizationPatterns(patterns, ctx);
     linalg::PackOp::getCanonicalizationPatterns(patterns, ctx);
     linalg::UnPackOp::getCanonicalizationPatterns(patterns, ctx);
-    linalg::populateFoldIntoPackAndUnpackPatterns(patterns);
+    // Since some of the folding patterns associated to pack/unpack ops inhibit
+    // fusion, we use a control function to rule out the application of these
+    // patterns in those cases.
+    linalg::populateFoldIntoPackAndUnpackPatterns(
+        patterns, [](OpOperand *opOperand) {
+          Operation *producer = opOperand->get().getDefiningOp();
+          Operation *consumer = opOperand->getOwner();
+          // If we have a pack/unpack consumer and a producer that has multiple
+          // uses, this _probably_ means the producer won't get dce'd. If that
+          // is the case, by folding the consumer pack/unpack, we break the
+          // producer consumer chain between them and inhibit fusion later in
+          // the pipeline.
+          if (isa<linalg::PackOp, linalg::UnPackOp>(consumer) &&
+              isa<TilingInterface>(producer) && !producer->hasOneUse())
+            return false;
+          // TODO(egebeysel): Technically speaking, we can also have other cases
+          // over here where we want to inhibit these folding patterns, e.g.
+          // when we have pack/unpack ops as producers with multiple consumers,
+          // which essentially duplicates the number of these ops. Although as
+          // of now, we don't really come across such dispatches so this stays
+          // over here.
+          return true;
+        });
     memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
     if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       funcOp.emitOpError("folding patterns failed");


### PR DESCRIPTION
This is step 2/3 of fixing the large vector sizes found compilation failure (roo-389). This PR adds the control function that would allow us to prevent folding pack/unpack operations into (transpose) ops that has multiple uses, e.g. the result is stored into a dispatch. 

To begin with, ending up with such dispatches is also problematic in means of memory footprint, but I guess fixing that would be a much more involved issue. So, this PR enables fusion by blocking inhibiting folding patterns. See IREE issue #20896 for more details.

The change I made, and therefore the test that would be changed is actually target-agnostic. Although generally, the pass that utilizes it isn't. So I just put it into one of them. If anyone has a better idea of where to put the test, please tell me :) Theoretically, I can put it in a new file that is dedicated to checking if these patterns are blocked or not - also would be a place to put future patterns to block over there. But I assume this would rarely be updated, so idk.

TODO:
- [x] Add and/or adjust tests.