### PR TITLE
Bridge from Vulkan sema to native wait handle

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
@@ -71,7 +71,10 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal",
         "//runtime/src/iree/base/internal:arena",
+        "//runtime/src/iree/base/internal:event_pool",
         "//runtime/src/iree/base/internal:synchronization",
+        "//runtime/src/iree/base/internal:threading",
+        "//runtime/src/iree/base/internal:wait_handle",
         "//runtime/src/iree/base/internal/flatcc:parsing",
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/drivers/vulkan/builtin",
@@ -87,6 +90,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/schemas:executable_debug_info_c_fbs",
         "//runtime/src/iree/schemas:vulkan_executable_def_c_fbs",
         "@vulkan_headers",
+        ":timepoint_bridge",
     ],
 )
 
@@ -117,6 +121,43 @@ iree_runtime_cc_test(
     deps = [
         ":dynamic_symbols",
         "//runtime/src/iree/base",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+iree_runtime_cc_library(
+    name = "timepoint_bridge",
+    srcs = [
+        "native_semaphore.h",
+        "timepoint_bridge.cc",
+    ],
+    hdrs = ["timepoint_bridge.h"],
+    deps = [
+        ":dynamic_symbols",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal",
+        "//runtime/src/iree/base/internal:arena",
+        "//runtime/src/iree/base/internal:event_pool",
+        "//runtime/src/iree/base/internal:synchronization",
+        "//runtime/src/iree/base/internal:threading",
+        "//runtime/src/iree/base/internal:wait_handle",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/utils:semaphore_base",
+        "//runtime/src/iree/schemas:executable_debug_info_c_fbs",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "timepoint_bridge_test",
+    srcs = [
+        "timepoint_bridge_test.cc",
+    ],
+    features = ["-layering_check"],
+    deps = [
+         ":timepoint_bridge",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/hal/drivers/null:null",
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",
     ],

--- a/runtime/src/iree/hal/drivers/vulkan/native_semaphore.h
+++ b/runtime/src/iree/hal/drivers/vulkan/native_semaphore.h
@@ -38,7 +38,11 @@ VkSemaphore iree_hal_vulkan_native_semaphore_handle(
 iree_status_t iree_hal_vulkan_native_semaphore_multi_wait(
     iree::hal::vulkan::VkDeviceHandle* logical_device,
     const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout,
-    VkSemaphoreWaitFlags wait_flags);
+    VkSemaphoreWaitFlags wait_flags, uint64_t* out_values = nullptr);
+
+iree_status_t iree_hal_vulkan_native_semaphore_multi_wait_any(
+    const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout,
+    uint64_t* out_values = nullptr);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/hal/drivers/vulkan/timepoint_bridge.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/timepoint_bridge.cc
@@ -1,0 +1,375 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "timepoint_bridge.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#define VULKAN_TIMEPOINT_BRIDGE_POOL_SIZE 16
+
+// TODO iree_hal_semaphore_timepoint_t and timepoint deadline
+// TODO multi import
+// TODO freeing of event
+// TODO disable by default
+
+iree_status_t iree_hal_vulkan_timepoint_bridge_wait_set_initialize(
+    iree_allocator_t allocator,
+    iree_hal_vulkan_timepoint_bridge_multi_wait_any_fn_t multi_wait,
+    iree_hal_vulkan_timepoint_bridge_wait_set *out_wait_set) {
+  memset(out_wait_set, 0, sizeof(*out_wait_set));
+
+  iree_status_t status = iree_allocator_malloc(
+      allocator, VULKAN_TIMEPOINT_BRIDGE_POOL_SIZE * sizeof(uint64_t),
+      (void **)&out_wait_set->handles.payload_values);
+
+  IREE_CHECK_OK(status);
+
+  status = iree_allocator_malloc(
+      allocator,
+      VULKAN_TIMEPOINT_BRIDGE_POOL_SIZE * sizeof(iree_hal_semaphore_t *),
+      (void **)&out_wait_set->handles.semaphores);
+
+  IREE_CHECK_OK(status);
+
+  out_wait_set->capacity = VULKAN_TIMEPOINT_BRIDGE_POOL_SIZE;
+  out_wait_set->multi_wait = multi_wait;
+  return status;
+}
+
+iree_status_t iree_hal_vulkan_timepoint_bridge_signal_set_initialize(
+    iree_allocator_t allocator,
+    iree_hal_vulkan_timepoint_bridge_signal_set_t *out_wait_set) {
+  memset(out_wait_set, 0, sizeof(*out_wait_set));
+
+  iree_status_t status = iree_allocator_malloc(
+      allocator, VULKAN_TIMEPOINT_BRIDGE_POOL_SIZE * sizeof(iree_event_t *),
+      (void **)&out_wait_set->handles.events);
+
+  out_wait_set->capacity = VULKAN_TIMEPOINT_BRIDGE_POOL_SIZE;
+  return status;
+}
+
+iree_status_t iree_hal_vulkan_timepoint_bridge_wait_set_insert(
+    iree_hal_vulkan_timepoint_bridge_wait_set_t *wait_set,
+    iree_hal_semaphore_t *semaphore, uint64_t value) {
+  if (wait_set->capacity > wait_set->handles.count) {
+    // keep the semaphore alive while it is waited for
+    iree_hal_semaphore_retain(semaphore);
+
+    iree_host_size_t wait_set_tail_index = wait_set->handles.count;
+    wait_set->handles.semaphores[wait_set_tail_index] = semaphore;
+    wait_set->handles.payload_values[wait_set_tail_index] = value;
+    ++(wait_set->handles.count);
+
+    return iree_ok_status();
+  }
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED, "realloc not impl");
+}
+
+iree_status_t iree_hal_vulkan_timepoint_bridge_import(
+    iree_hal_vulkan_timepoint_bridge_t *bridge, iree_hal_semaphore_t *semaphore,
+    uint64_t value, iree_event_t *event) {
+  IREE_ASSERT_ARGUMENT(bridge);
+  IREE_ASSERT_ARGUMENT(semaphore);
+  IREE_ASSERT_ARGUMENT(event);
+  iree_hal_semaphore_retain(semaphore);
+  iree_slim_mutex_lock(&(bridge->mutex));
+  bridge->pending_imports.semaphore = semaphore;
+  bridge->pending_imports.value = value;
+  bridge->pending_imports.event = event;
+  iree_slim_mutex_unlock(&(bridge->mutex));
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_vulkan_timepoint_bridge_signal_set_insert(
+    iree_hal_vulkan_timepoint_bridge_signal_set_t *wait_set,
+    iree_event_t *event) {
+  if (wait_set->capacity > wait_set->handles.count) {
+    iree_host_size_t wait_set_tail_index = wait_set->handles.count;
+    wait_set->handles.events[wait_set_tail_index] = event;
+    ++(wait_set->handles.count);
+
+    return iree_ok_status();
+  }
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED, "realloc not impl");
+}
+
+iree_status_t iree_hal_vulkan_timepoint_bridge_wait_set_erase(
+    iree_hal_vulkan_timepoint_bridge_wait_set_t *wait_set, size_t index) {
+  assert(wait_set->handles.count > 0);
+  iree_hal_semaphore_release(wait_set->handles.semaphores[index]);
+
+  wait_set->handles.semaphores[index] = NULL;
+  wait_set->handles.payload_values[index] = 0;
+  // swap with last
+
+  size_t tail_index = wait_set->handles.count - 1;
+  if (index != tail_index) {
+    wait_set->handles.semaphores[index] =
+        wait_set->handles.semaphores[tail_index];
+    wait_set->handles.payload_values[index] =
+        wait_set->handles.payload_values[tail_index];
+  }
+
+  wait_set->handles.count = tail_index;
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_vulkan_timepoint_bridge_signal_set_signal(
+    iree_hal_vulkan_timepoint_bridge_signal_set_t *signal_set, size_t index) {
+  assert(signal_set->handles.count > index);
+  if (signal_set->handles.events[index] != NULL)
+    iree_event_set(signal_set->handles.events[index]);
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_vulkan_timepoint_bridge_signal_set_erase(
+    iree_hal_vulkan_timepoint_bridge_signal_set_t *wait_set, size_t index) {
+  assert(wait_set->handles.count > 0);
+
+  wait_set->handles.events[index] = NULL;
+  // swap with last
+
+  size_t tail_index = wait_set->handles.count - 1;
+  if (index != tail_index) {
+    wait_set->handles.events[index] = wait_set->handles.events[tail_index];
+  }
+
+  wait_set->handles.count = tail_index;
+  return iree_ok_status();
+}
+
+void vulkan_iree_hal_vulkan_timepoint_bridge_wait_set_wait_any(
+    iree_hal_vulkan_timepoint_bridge_wait_set_t *wait_set,
+    iree_timeout_t earliest_deadline_ns, uint64_t *resolved_values) {
+  IREE_ASSERT_ARGUMENT(wait_set);
+
+  if (wait_set->handles.count > 0) {
+    iree_status_t status = wait_set->multi_wait(
+        &wait_set->handles, earliest_deadline_ns, resolved_values);
+    // TODO handle status
+
+    // check which to notify
+    for (iree_host_size_t i = 0; i < wait_set->handles.count; ++i) {
+      if (resolved_values[i] >= wait_set->handles.payload_values[i]) {
+        resolved_values[i] = true;
+      } else {
+        resolved_values[i] = false;
+      }
+    }
+  }
+}
+
+iree_status_t iree_hal_vulkan_timepoint_bridge_initialize(
+    iree_allocator_t allocator, iree_hal_semaphore_t *wake_event,
+    iree_hal_vulkan_timepoint_bridge_multi_wait_any_fn_t multi_wait,
+    iree_hal_vulkan_timepoint_bridge_t *out_bridge) {
+  IREE_ASSERT_ARGUMENT(out_bridge);
+
+  iree_status_t status = iree_hal_vulkan_timepoint_bridge_wait_set_initialize(
+      allocator, multi_wait, &out_bridge->wait_set);
+  IREE_CHECK_OK(status);
+
+  status = iree_hal_vulkan_timepoint_bridge_signal_set_initialize(
+      allocator, &out_bridge->signal_set);
+  IREE_CHECK_OK(status);
+
+  status = iree_hal_vulkan_timepoint_bridge_insert(out_bridge, wake_event, 1,
+                                                   nullptr);
+  IREE_CHECK_OK(status);
+
+  out_bridge->allocator = allocator;
+  out_bridge->pending_imports.semaphore = NULL;
+  out_bridge->pending_imports.event = NULL;
+
+  out_bridge->state = IREE_HAL_VULKAN_TIMEPOINT_BRIDGE_STATE_SUSPENDED;
+
+  iree_slim_mutex_initialize(&out_bridge->mutex);
+
+  IREE_CHECK_OK(status);
+  return status;
+}
+
+void iree_hal_vulkan_timepoint_bridge_free(
+    iree_hal_vulkan_timepoint_bridge_t *bridge) {
+  IREE_ASSERT_ARGUMENT(bridge);
+
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_allocator_t allocator = bridge->allocator;
+  for (iree_host_size_t i = 0; i < bridge->wait_set.handles.count; ++i) {
+    iree_hal_semaphore_release(bridge->wait_set.handles.semaphores[i]);
+  }
+
+  if (bridge->pending_imports.semaphore)
+    iree_hal_semaphore_release(bridge->pending_imports.semaphore);
+
+  iree_allocator_free(allocator, bridge->wait_set.handles.payload_values);
+  iree_allocator_free(allocator, bridge->wait_set.handles.semaphores);
+  iree_allocator_free(allocator, bridge->signal_set.handles.events);
+
+  iree_slim_mutex_deinitialize(&bridge->mutex);
+  IREE_TRACE_ZONE_END(z0);
+
+#ifndef NDEBUG
+  memset(bridge, 0, sizeof(*bridge));
+#endif
+}
+
+iree_status_t iree_hal_vulkan_timepoint_bridge_insert(
+    iree_hal_vulkan_timepoint_bridge_t *bridge, iree_hal_semaphore_t *semaphore,
+    uint64_t value, iree_event_t *event) {
+  IREE_ASSERT_ARGUMENT(bridge);
+  IREE_ASSERT_ARGUMENT(semaphore);
+
+  iree_status_t status = iree_hal_vulkan_timepoint_bridge_wait_set_insert(
+      &bridge->wait_set, semaphore, value);
+  IREE_CHECK_OK(status);
+  status = iree_hal_vulkan_timepoint_bridge_signal_set_insert(
+      &bridge->signal_set, event);
+  IREE_CHECK_OK(status);
+
+  iree_hal_semaphore_signal(bridge->wait_set.handles.semaphores[0],
+                            bridge->wait_set.handles.payload_values[0] + 1);
+  return status;
+}
+
+iree_status_t iree_hal_vulkan_timepoint_bridge_pump(
+    iree_hal_vulkan_timepoint_bridge_t *bridge) {
+  uint64_t *semaphore_values = (uint64_t *)iree_alloca(
+      bridge->wait_set.handles.count * sizeof(uint64_t));
+
+  vulkan_iree_hal_vulkan_timepoint_bridge_wait_set_wait_any(
+      &bridge->wait_set, iree_infinite_timeout(), semaphore_values);
+
+  // check which to notify
+  for (iree_host_size_t i = 0; i < bridge->wait_set.handles.count; ++i) {
+    if (semaphore_values[i]) {
+      iree_hal_vulkan_timepoint_bridge_signal_set_signal(&bridge->signal_set,
+                                                         i);
+    }
+  }
+
+  for (iree_host_size_t i = 0; i < bridge->wait_set.handles.count; ++i) {
+    if (semaphore_values[i]) {
+      if (i == 0) {
+        iree_slim_mutex_lock(&bridge->mutex);
+        if (bridge->pending_imports.semaphore != NULL) {
+          iree_hal_vulkan_timepoint_bridge_insert(
+              bridge, bridge->pending_imports.semaphore,
+              bridge->pending_imports.value, bridge->pending_imports.event);
+          memset(&bridge->pending_imports, 0, sizeof(bridge->pending_imports));
+        }
+        iree_slim_mutex_unlock(&bridge->mutex);
+        if (bridge->wait_set.handles.payload_values[i] != SEM_VALUE_MAX)
+          ++bridge->wait_set.handles.payload_values[i];
+
+      } else {
+        iree_hal_vulkan_timepoint_bridge_signal_set_erase(&bridge->signal_set,
+                                                          i);
+      }
+    }
+  }
+
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_vulkan_timepoint_bridge_erase(
+    iree_hal_vulkan_timepoint_bridge_t *bridge, size_t index) {
+  iree_hal_vulkan_timepoint_bridge_wait_set_erase(&bridge->wait_set, index);
+  iree_hal_vulkan_timepoint_bridge_signal_set_erase(&bridge->signal_set, index);
+  return iree_ok_status();
+}
+
+void iree_hal_vulkan_timepoint_bridge_pump_until_exit(
+    iree_hal_vulkan_timepoint_bridge_t *bridge) {
+  while (true) {
+    if (iree_atomic_load(&bridge->state, iree_memory_order_acquire) ==
+        IREE_HAL_VULKAN_TIMEPOINT_BRIDGE_STATE_EXITING) {
+      // Thread exit requested - cancel pumping.
+      break;
+    }
+
+    IREE_TRACE_ZONE_BEGIN_NAMED(
+        z0, "iree_hal_vulkan_timepoint_bridge_pump_until_exit");
+
+    iree_hal_vulkan_timepoint_bridge_pump(bridge);
+    IREE_TRACE_ZONE_END(z0);
+  }
+}
+
+int vulkan_iree_hal_vulkan_timepoint_bridge_main(
+    iree_hal_vulkan_timepoint_bridge_t *bridge) {
+  IREE_TRACE_ZONE_BEGIN(thread_zone);
+
+  // iree_thread_request_affinity(bridge->thread,
+  // bridge->ideal_thread_affinity);
+
+  // Enter the running state immediately. Note that we could have been
+  // requested to exit while suspended/still starting up, so check that here
+  // before we mess with any data structures.
+  const bool should_run =
+      iree_atomic_exchange(&bridge->state,
+                           IREE_HAL_VULKAN_TIMEPOINT_BRIDGE_STATE_RUNNING,
+                           iree_memory_order_acq_rel) !=
+      IREE_HAL_VULKAN_TIMEPOINT_BRIDGE_STATE_EXITING;
+  if (IREE_LIKELY(should_run)) {
+    // << work happens here >>
+    iree_hal_vulkan_timepoint_bridge_pump_until_exit(bridge);
+  }
+
+  IREE_TRACE_ZONE_END(thread_zone);
+  iree_atomic_store(&bridge->state,
+                    IREE_HAL_VULKAN_TIMEPOINT_BRIDGE_STATE_ZOMBIE,
+                    iree_memory_order_release);
+
+  return 0;
+}
+
+iree_status_t iree_hal_vulkan_timepoint_bridge_create(
+    iree_hal_vulkan_timepoint_bridge_t *out_bridge) {
+  iree_hal_vulkan_timepoint_bridge_t *bridge = NULL;
+
+  iree_status_t status = iree_ok_status();
+
+  // Start background thread
+  if (iree_status_is_ok(status)) {
+    iree_thread_create_params_t params;
+    memset(&params, 0, sizeof(params));
+    params.name = iree_make_cstring_view("iree_hal_vulkan_timepoint_bridge");
+    params.create_suspended = false;
+    params.priority_class = IREE_THREAD_PRIORITY_CLASS_NORMAL;
+    status = iree_thread_create(
+        (iree_thread_entry_t)vulkan_iree_hal_vulkan_timepoint_bridge_main,
+        bridge, params, bridge->allocator, &bridge->thread);
+  }
+
+  return status;
+}
+
+void iree_hal_vulkan_timepoint_bridge_request_exit(
+    iree_hal_vulkan_timepoint_bridge_t *bridge) {
+  // Signal thread to exit
+  iree_atomic_store(&bridge->state,
+                    IREE_HAL_VULKAN_TIMEPOINT_BRIDGE_STATE_EXITING,
+                    iree_memory_order_acq_rel);
+  iree_hal_semaphore_signal(bridge->wait_set.handles.semaphores[0],
+                            SEM_VALUE_MAX);
+}
+
+void iree_hal_vulkan_timepoint_bridge_destroy(
+    iree_hal_vulkan_timepoint_bridge_t *bridge) {
+  // Wait for thread to exit
+  if (bridge->thread) {
+    iree_thread_join(bridge->thread);
+    iree_thread_release(bridge->thread);
+  }
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/runtime/src/iree/hal/drivers/vulkan/timepoint_bridge.h
+++ b/runtime/src/iree/hal/drivers/vulkan/timepoint_bridge.h
@@ -1,0 +1,196 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_VULKAN_TIMEPOINT_BRIDGE_H_
+#define IREE_HAL_DRIVERS_VULKAN_TIMEPOINT_BRIDGE_H_
+
+#include "iree/base/api.h"
+#include "iree/base/internal/synchronization.h"
+#include "iree/base/internal/threading.h"
+#include "iree/base/internal/wait_handle.h"
+#include "iree/hal/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// This thread waits on a set of vulkan semaphore timeline timepoints (there is
+// potential to generalize this), and notifies a corresponding wait_primitive
+// once signaled. The goal is to make timepoints exportable for usage ooutside
+// of a specific driver. This is somewhat analogous to the task poller thread.
+
+typedef enum iree_hal_vulkan_timepoint_bridge_state_e : int32_t {
+  // Wait thread has been created in a suspended state and must be resumed to
+  // wake for the first time.
+  IREE_HAL_VULKAN_TIMEPOINT_BRIDGE_STATE_SUSPENDED = 0,
+  // Wait thread is running and servicing wait tasks.
+  IREE_HAL_VULKAN_TIMEPOINT_BRIDGE_STATE_RUNNING = 1,
+  // Wait thread should exit (or is exiting) and will soon enter the zombie
+  // state.
+  IREE_HAL_VULKAN_TIMEPOINT_BRIDGE_STATE_EXITING = 2,
+  // Wait thread has exited and entered a 🧟 state (waiting for join).
+  // The thread handle is still valid and must be destroyed.
+  IREE_HAL_VULKAN_TIMEPOINT_BRIDGE_STATE_ZOMBIE = 3,
+} iree_hal_vulkan_timepoint_bridge_state_t;
+
+// Represents a pending import waiting for an external timepoint
+typedef struct iree_hal_vulkan_timepoint_bridge_external_import_t {
+  // The HAL semaphore to signal when ready
+  iree_hal_semaphore_t *semaphore;
+  uint64_t value;
+  iree_event_t *event;
+  struct iree_hal_vulkan_timepoint_bridge_external_import_t *next;
+} iree_hal_vulkan_timepoint_bridge_external_import_t;
+
+// TODO deadlines
+
+typedef struct iree_hal_event_list_t {
+  iree_host_size_t count;
+  iree_event_t **events;
+} iree_hal_event_list_t;
+
+typedef struct iree_hal_vulkan_timepoint_bridge_signal_set {
+  iree_hal_event_list_t handles;
+  size_t capacity;
+} iree_hal_vulkan_timepoint_bridge_signal_set_t;
+
+typedef iree_status_t (*iree_hal_vulkan_timepoint_bridge_multi_wait_any_fn_t)(
+    const iree_hal_semaphore_list_t *semaphore_list, iree_timeout_t timeout,
+    uint64_t *out_values);
+
+typedef struct iree_hal_vulkan_timepoint_bridge_wait_set {
+  iree_hal_semaphore_list_t handles;
+  size_t capacity;
+  iree_hal_vulkan_timepoint_bridge_multi_wait_any_fn_t multi_wait;
+} iree_hal_vulkan_timepoint_bridge_wait_set_t;
+
+// Represents a bridge for Vulkan timepoints to HAL events.
+typedef struct iree_hal_vulkan_timepoint_bridge {
+  iree_allocator_t allocator;
+  // thread waiting on timepoints.
+  iree_thread_t *thread;
+  // Mutex guarding access to pending_imports.
+  iree_slim_mutex_t mutex;
+  // Pending pair of timepoint and event to be inserted into the bridge.
+  iree_hal_vulkan_timepoint_bridge_external_import_t pending_imports
+      IREE_GUARDED_BY(mutex);
+  // Set of timepoints currently being waited on.
+  iree_hal_vulkan_timepoint_bridge_wait_set_t wait_set;
+  // Set of timepoints to be signaled.
+  iree_hal_vulkan_timepoint_bridge_signal_set_t signal_set;
+  iree_atomic_int32_t state;
+} iree_hal_vulkan_timepoint_bridge_t;
+
+// Initializes a wait set for Vulkan timepoint bridge semaphores.
+iree_status_t iree_hal_vulkan_timepoint_bridge_wait_set_initialize(
+    iree_allocator_t allocator,
+    iree_hal_vulkan_timepoint_bridge_multi_wait_any_fn_t,
+    iree_hal_vulkan_timepoint_bridge_wait_set_t *out_wait_set);
+
+// Initializes a signal set for Vulkan timepoint bridge events.
+// |out_wait_set|: Initialized signal set.
+iree_status_t iree_hal_vulkan_timepoint_bridge_signal_set_initialize(
+    iree_allocator_t allocator,
+    iree_hal_vulkan_timepoint_bridge_signal_set_t *out_wait_set);
+
+// Inserts a semaphore and value into the wait set.
+// |wait_set|: The wait set to insert into.
+// |semaphore|: Semaphore to wait on.
+// |value|: Value to wait for.
+iree_status_t iree_hal_vulkan_timepoint_bridge_wait_set_insert(
+    iree_hal_vulkan_timepoint_bridge_wait_set_t *wait_set,
+    iree_hal_semaphore_t *semaphore, uint64_t value);
+
+// Inserts an event and value into the signal set.
+// |wait_set|: The signal set to insert into.
+// |event|: Event to signal.
+iree_status_t iree_hal_vulkan_timepoint_bridge_signal_set_insert(
+    iree_hal_vulkan_timepoint_bridge_signal_set_t *wait_set,
+    iree_event_t *event);
+
+// Removes an entry from the wait set by index.
+iree_status_t iree_hal_vulkan_timepoint_bridge_wait_set_erase(
+    iree_hal_vulkan_timepoint_bridge_wait_set_t *wait_set, size_t index);
+
+// Signals an event in the signal set by index.
+// |index|: Index of the event to signal.
+iree_status_t iree_hal_vulkan_timepoint_bridge_signal_set_signal(
+    iree_hal_vulkan_timepoint_bridge_signal_set_t *signal_set, size_t index);
+
+// Removes an entry from the signal set by index.
+iree_status_t iree_hal_vulkan_timepoint_bridge_signal_set_erase(
+    iree_hal_vulkan_timepoint_bridge_signal_set_t *wait_set, size_t index);
+
+// Waits for any semaphore in the wait set to be signaled.
+// |wait_set|: The wait set to wait on.
+// |earliest_deadline_ns|: Timeout deadline in nanoseconds.
+// |resolved_values|: Output array for values.
+void vulkan_iree_hal_vulkan_timepoint_bridge_wait_set_wait_any(
+    iree_hal_vulkan_timepoint_bridge_wait_set_t *wait_set,
+    iree_timeout_t earliest_deadline_ns, uint64_t *resolved_values);
+
+// Inserts a semaphore, value, and event into the bridge for tracking.
+// |semaphore|: Semaphore to track.
+// |value|: Value to wait for.
+// |event|: Event to signal when ready.
+iree_status_t iree_hal_vulkan_timepoint_bridge_insert(
+    iree_hal_vulkan_timepoint_bridge_t *bridge, iree_hal_semaphore_t *semaphore,
+    uint64_t value, iree_event_t *event);
+
+// Imports a semaphore, event pair into the bridge.
+iree_status_t iree_hal_vulkan_timepoint_bridge_import(
+    iree_hal_vulkan_timepoint_bridge_t *bridge, iree_hal_semaphore_t *semaphore,
+    uint64_t value, iree_event_t *event);
+
+// Initializes a Vulkan timepoint bridge.
+// |allocator|: Allocator for memory management.
+// |wake_event|: Semaphore to wake the bridge thread.
+// |multi_wait|: Function pointer for multi-wait implementation.
+// |out_bridge|: Output pointer for the initialized bridge.
+iree_status_t iree_hal_vulkan_timepoint_bridge_initialize(
+    iree_allocator_t allocator, iree_hal_semaphore_t *wake_event,
+    iree_hal_vulkan_timepoint_bridge_multi_wait_any_fn_t multi_wait,
+    iree_hal_vulkan_timepoint_bridge_t *out_bridge);
+
+// Creates a bridge thread and starts it.
+iree_status_t iree_hal_vulkan_timepoint_bridge_create(
+    iree_hal_vulkan_timepoint_bridge_t *out_bridge);
+
+// Joins the bridge thread and releases it.
+void iree_hal_vulkan_timepoint_bridge_destroy(
+    iree_hal_vulkan_timepoint_bridge_t *out_bridge);
+
+// Frees memory associated with a Vulkan timepoint bridge.
+void iree_hal_vulkan_timepoint_bridge_free(
+    iree_hal_vulkan_timepoint_bridge_t *bridge);
+
+// Pumps the bridge to process pending timepoints.
+iree_status_t iree_hal_vulkan_timepoint_bridge_pump(
+    iree_hal_vulkan_timepoint_bridge_t *bridge);
+
+// Removes an entry from the bridge by index.
+iree_status_t iree_hal_vulkan_timepoint_bridge_erase(
+    iree_hal_vulkan_timepoint_bridge_t *bridge, size_t index);
+
+// Continuously pumps the bridge until an exit is requested.
+void iree_hal_vulkan_timepoint_bridge_pump_until_exit(
+    iree_hal_vulkan_timepoint_bridge_t *bridge);
+
+// Main thread function for the timepoint bridge.
+// Returns 0 on success.
+int vulkan_iree_hal_vulkan_timepoint_bridge_main(
+    iree_hal_vulkan_timepoint_bridge_t *bridge);
+
+// Requests the bridge thread to exit.
+// |bridge|: The timepoint bridge bridge.
+void iree_hal_vulkan_timepoint_bridge_request_exit(
+    iree_hal_vulkan_timepoint_bridge_t *bridge);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif

--- a/runtime/src/iree/hal/drivers/vulkan/timepoint_bridge_test.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/timepoint_bridge_test.cc
@@ -1,0 +1,190 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "timepoint_bridge.h"
+
+#include "iree/base/api.h"
+#include "iree/hal/utils/semaphore_base.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+#ifdef __cplusplus
+extern "C" {
+namespace iree {
+namespace {
+
+#endif  // __cplusplus
+
+static void iree_hal_test_semaphore_destroy(
+    iree_hal_semaphore_t* base_semaphore) {};
+static iree_status_t iree_hal_test_semaphore_signal(
+    iree_hal_semaphore_t* base_semaphore, uint64_t new_value) {
+  return iree_ok_status();
+};
+
+const iree_hal_semaphore_vtable_t iree_hal_test_semaphore_vtable = {
+    iree_hal_test_semaphore_destroy,
+    NULL,
+    iree_hal_test_semaphore_signal,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+};
+
+typedef struct iree_hal_test_semaphore_t {
+  // Abstract resource used for injecting reference counting and vtable;
+  // must be at offset 0.
+  iree_hal_semaphore_t base;
+};
+
+static iree_hal_test_semaphore_t iree_hal_test_semaphore_create() {
+  iree_hal_test_semaphore_t out_semaphore;
+  iree_hal_semaphore_initialize(&iree_hal_test_semaphore_vtable,
+                                &out_semaphore.base);
+  return out_semaphore;
+}
+
+iree_status_t multi_wait(const iree_hal_semaphore_list_t* semaphore_list,
+                         iree_timeout_t timeout, uint64_t* out_values) {
+  return iree_ok_status();
+};
+
+// Tests initialization of the timepoint bridge.
+TEST(TimepointBridge, Initialize) {
+  iree_hal_vulkan_timepoint_bridge_t bridge;
+  auto allocator = iree_allocator_system();
+  iree_hal_test_semaphore_t null_semaphore = iree_hal_test_semaphore_create();
+  iree_hal_vulkan_timepoint_bridge_multi_wait_any_fn_t multi_wait_fn =
+      &multi_wait;
+
+  IREE_ASSERT_OK(iree_hal_vulkan_timepoint_bridge_initialize(
+      iree_allocator_system(), (iree_hal_semaphore_t*)&null_semaphore,
+      multi_wait_fn, &bridge));
+  ASSERT_EQ(bridge.state, IREE_HAL_VULKAN_TIMEPOINT_BRIDGE_STATE_SUSPENDED);
+  ASSERT_EQ(bridge.allocator.ctl, iree_allocator_system().ctl);
+
+  ASSERT_EQ(bridge.signal_set.capacity, 16);
+  ASSERT_EQ(bridge.wait_set.capacity, 16);
+
+  ASSERT_EQ(bridge.signal_set.handles.count, 1);
+  ASSERT_EQ(bridge.wait_set.handles.count, 1);
+  ASSERT_NE(bridge.wait_set.handles.payload_values, nullptr);
+  ASSERT_EQ(bridge.wait_set.handles.semaphores[0],
+            (iree_hal_semaphore_t*)&null_semaphore);
+  ASSERT_EQ(bridge.wait_set.multi_wait, &multi_wait);
+
+  iree_hal_vulkan_timepoint_bridge_free(&bridge);
+}
+
+// Tests insertion and erasure of timepoints of the timepoint bridge.
+TEST(TimepointBridge, InsertErase) {
+  {
+    iree_hal_vulkan_timepoint_bridge_t bridge;
+    auto allocator = iree_allocator_system();
+
+    iree_event_t event;
+    iree_hal_test_semaphore_t null_semaphore = iree_hal_test_semaphore_create();
+    iree_hal_vulkan_timepoint_bridge_multi_wait_any_fn_t multi_wait_fn =
+        &multi_wait;
+
+    IREE_ASSERT_OK(iree_hal_vulkan_timepoint_bridge_initialize(
+        iree_allocator_system(), (iree_hal_semaphore_t*)&null_semaphore,
+        multi_wait_fn, &bridge));
+    int items = 1;
+
+    IREE_ASSERT_OK(iree_hal_vulkan_timepoint_bridge_insert(
+        &bridge, (iree_hal_semaphore_t*)&null_semaphore, 2, &event));
+    ++items;
+
+    ASSERT_EQ(bridge.wait_set.handles.payload_values[items - 1], 2);
+    iree_hal_vulkan_timepoint_bridge_erase(&bridge, 0);
+    --items;
+
+    ASSERT_EQ(bridge.signal_set.handles.count, items);
+    ASSERT_EQ(bridge.wait_set.handles.count, items);
+
+    IREE_ASSERT_OK(iree_hal_vulkan_timepoint_bridge_insert(
+        &bridge, (iree_hal_semaphore_t*)&null_semaphore, 1, &event));
+    ++items;
+    IREE_ASSERT_OK(iree_hal_vulkan_timepoint_bridge_insert(
+        &bridge, (iree_hal_semaphore_t*)&null_semaphore, 1, &event));
+    ++items;
+    IREE_ASSERT_OK(iree_hal_vulkan_timepoint_bridge_insert(
+        &bridge, (iree_hal_semaphore_t*)&null_semaphore, 3, &event));
+    ++items;
+    ASSERT_EQ(bridge.signal_set.handles.count, items);
+    ASSERT_EQ(bridge.wait_set.handles.count, items);
+    ASSERT_EQ(bridge.wait_set.handles.payload_values[items - 1], 3);
+
+    iree_hal_vulkan_timepoint_bridge_erase(&bridge, 1);
+    --items;
+    ASSERT_EQ(bridge.wait_set.handles.payload_values[1], 3);
+    ASSERT_EQ(bridge.signal_set.handles.count, items);
+    ASSERT_EQ(bridge.wait_set.handles.count, items);
+    ASSERT_EQ(bridge.wait_set.handles.payload_values[items - 1], 1);
+
+    iree_hal_vulkan_timepoint_bridge_free(&bridge);
+  }
+  {
+    auto allocator = iree_allocator_system();
+    iree_event_t event;
+    iree_hal_test_semaphore_t null_semaphore = iree_hal_test_semaphore_create();
+    iree_hal_vulkan_timepoint_bridge_multi_wait_any_fn_t multi_wait_fn =
+        &multi_wait;
+    iree_hal_vulkan_timepoint_bridge_t bridge;
+
+    IREE_ASSERT_OK(iree_hal_vulkan_timepoint_bridge_initialize(
+        iree_allocator_system(), (iree_hal_semaphore_t*)&null_semaphore,
+        multi_wait_fn, &bridge));
+
+    for (int i = 0; i < 15; ++i) {
+      IREE_ASSERT_OK(iree_hal_vulkan_timepoint_bridge_insert(
+          &bridge, (iree_hal_semaphore_t*)&null_semaphore, 1, &event));
+    }
+
+    iree_hal_vulkan_timepoint_bridge_erase(&bridge, 0);
+
+    IREE_ASSERT_OK(iree_hal_vulkan_timepoint_bridge_insert(
+        &bridge, (iree_hal_semaphore_t*)&null_semaphore, 1, &event));
+
+    iree_hal_vulkan_timepoint_bridge_free(&bridge);
+  }
+}
+
+// Tests import into the timepoint bridge.
+TEST(TimepointBridge, Import) {
+  auto allocator = iree_allocator_system();
+
+  iree_event_t event;
+  iree_event_initialize(0, &event);
+
+  iree_hal_test_semaphore_t null_semaphore = iree_hal_test_semaphore_create();
+  iree_hal_vulkan_timepoint_bridge_multi_wait_any_fn_t multi_wait_fn =
+      &multi_wait;
+
+  iree_hal_vulkan_timepoint_bridge_t bridge;
+
+  IREE_ASSERT_OK(iree_hal_vulkan_timepoint_bridge_initialize(
+      iree_allocator_system(), (iree_hal_semaphore_t*)&null_semaphore,
+      multi_wait_fn, &bridge));
+
+  IREE_ASSERT_OK(iree_hal_vulkan_timepoint_bridge_import(
+      &bridge, (iree_hal_semaphore_t*)&null_semaphore, 1, &event));
+
+  iree_hal_vulkan_timepoint_bridge_pump(&bridge);
+  ASSERT_EQ(bridge.wait_set.handles.count, 2);
+
+  // // IREE_ASSERT_OK(iree_hal_vulkan_timepoint_bridge_import(
+  // //     &bridge, (iree_hal_semaphore_t*)&null_semaphore, 1, &event));
+  iree_hal_vulkan_timepoint_bridge_free(&bridge);
+}
+
+#ifdef __cplusplus
+}
+}
+}  // extern "C"
+#endif  // __cplusplus


### PR DESCRIPTION
### TL;DR

Add a timepoint bridge for Vulkan semaphores to enable cross-driver synchronization.

### What changed?

Added a new timepoint bridge implementation for the Vulkan HAL driver that:

- Creates a bridge between Vulkan timeline semaphores and IREE events
- Implements a polling mechanism to wait on Vulkan semaphores and signal corresponding events
- Provides thread management for the polling operation with proper lifecycle states
- Includes wait and signal set management for tracking semaphores and events

The implementation consists of two new files:
- `timepoint_bridge.h`: Defines the bridge data structures and API
- `timepoint_bridge.cc`: Implements the bridge functionality

### How to test?

The timepoint bridge can be tested by:
1. Creating a Vulkan semaphore
2. Initializing a timepoint bridge with the semaphore
3. Inserting events to be signaled when semaphore values are reached
4. Signaling the semaphore from Vulkan operations
5. Verifying that corresponding events are properly signaled

### Why make this change?

This change enables cross-driver synchronization by bridging Vulkan timeline semaphores to IREE's event system. This allows for:

- Coordination between different HAL drivers
- Exporting timepoints for usage outside of the Vulkan driver
- Enabling more flexible synchronization patterns in heterogeneous execution environments

The implementation is similar in concept to the task poller thread but specialized for Vulkan semaphore timeline points.