### PR TITLE
remove mutable args and async function created from torch funcConversion

### DIFF
--- a/compiler/plugins/input/Torch/InputConversion/FuncConversion.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/FuncConversion.cpp
@@ -34,68 +34,8 @@ namespace {
 // ----------------
 // This pass converts from the "torch" programming model to the "iree"
 // programming model by rewriting all functions and calls to operate on native
-// IREE types. In the process, synchronization is added as appropriate for any
-// mutable and immutable torch-level arguments.
-//
-// Currently, the result of this pass is that every torch-func is augmented
-// to be implemented in terms of IREE's "coarse fences" ABI. In this ABI,
-// there is a (wait, signal) fence pair added to the end of every function.
-// Since torch functions are single-exit, practically, this involves:
-//   * Adding preambles to convert function arguments to `tensor` (and native
-//     torch types via `torch_c`), adding coarse synchronization on import
-//     (presently for all buffer arguments but in the future could only be
-//     those which are not tied to fine grained fences).
-//   * Adding a postamble with a synchronization barrier on any produced
-//     or mutated tensors and appropriate exports/in-place tieing to buffers.
-//   * Generation of a synchronous wrapper function with the original name
-//     (the async function is named with an `$async` suffix) which internally
-//     sets up/waits on fences while delegating to the async function.
-//
-// Immutable tensor types
-// ----------------------
-//
-// Immutable tensor types are mapped to a buffer_view and subject to
-// `hal.tensor.import` on use. On return, they will be placed behind a
-// synchronization barrier and exported.
-//
-// Mutable types
-// -------------
-// Here we rely on the characteristic that at the torch level, conversion to
-// and from the value domain is only legal at certain well defined points in
-// the program (currently at graph edges but potentially in the future at
-// various control flow points). These conversions are modeled by:
-//   * `torch.copy.to_vtensor`: Copy from a mutable tensor (torch.tensor) to
-//     an immutable value (torch.vtensor).
-//   * `torch.copy.to_tensor`: Allocates a new mutable tensor and initializes it
-//     with the value of the given immutable tensor. Presently un-used.
-//   * `torch.overwrite.tensor.contents`: Updates the contents of a mutable
-//     tensor from a given immutable tensor.
-//
-// Note that when importing from Torch, these ops cannot just be added at will,
-// and they are only created as a result of structural conversions. Therefore,
-// we can rely on these invariants and assume that usage outside of this is an
-// invalid program.
+// IREE types.
 //===----------------------------------------------------------------------===//
-
-std::optional<std::pair<Value, Value>>
-getEnclosingWaitSignalFences(Operation *op) {
-  auto parentFuncOp = dyn_cast<IREE::Util::FuncOp>(op);
-  if (!parentFuncOp) {
-    parentFuncOp = parentFuncOp->getParentOfType<IREE::Util::FuncOp>();
-    if (!parentFuncOp)
-      return {};
-  }
-  Block *entryBlock = &parentFuncOp.front();
-  auto numArguments = entryBlock->getNumArguments();
-  Value coarseWaitFence = entryBlock->getArgument(numArguments - 2);
-  Value coarseSignalFence = entryBlock->getArgument(numArguments - 1);
-  return std::make_pair(coarseWaitFence, coarseSignalFence);
-}
-
-std::optional<std::pair<Value, Value>>
-getEnclosingWaitSignalFences(Value value) {
-  return getEnclosingWaitSignalFences(value.getParentRegion()->getParentOp());
-}
 
 Value convertToBuiltinTensor(OpBuilder &builder, Value possibleTorchTensor) {
   Type ty = possibleTorchTensor.getType();
@@ -120,19 +60,11 @@ Value convertToBuiltinTensor(OpBuilder &builder, Value possibleTorchTensor) {
 
 enum class TypeDisposition {
   IMMUTABLE_TENSOR,
-  MUTABLE_TENSOR,
   TORCH_PRIMITIVE,
   PASSTHROUGH,
-  FENCE,
 };
 
-struct BarrierResult {
-  BlockArgument storage;
-  Type torchType;
-  int returnIndex = -1;
-};
-
-struct ConvertedAsyncFunctionInfo {
+struct ConvertedFunctionInfo {
   IREE::Util::FuncOp funcOp;
   SmallVector<IREE::Util::ReturnOp> returnOps;
   SmallVector<DictionaryAttr> torchArgAttrs;
@@ -142,27 +74,9 @@ struct ConvertedAsyncFunctionInfo {
   SmallVector<TypeDisposition> inputDispositions;
   SmallVector<TypeDisposition> resultDispositions;
 
-  // Post processing state.
-  // Values that must be captured in the coarse barrier.
-  SmallVector<Value> barrierInputs;
-  // Meta data per barrier input: storage, torchType, returnIndex (or -1)
-  SmallVector<BarrierResult> barrierResultMeta;
-
   LogicalResult postProcess();
   LogicalResult convertImmutableTensorArg(BlockArgument argValue,
                                           Type torchType, OpBuilder &builder);
-  LogicalResult convertMutableTensorArg(BlockArgument argValue, Type torchType,
-                                        OpBuilder &builder);
-
-  void addBarrierInput(Value inputTensor, BlockArgument storage, Type torchType,
-                       int returnIndex) {
-    barrierInputs.push_back(inputTensor);
-    barrierResultMeta.emplace_back(BarrierResult{
-        storage,
-        torchType,
-        returnIndex,
-    });
-  }
 
   Attribute getTorchArgAttr(BlockArgument argValue, StringRef attrName) {
     return torchArgAttrs.empty()
@@ -176,7 +90,7 @@ struct ConvertedAsyncFunctionInfo {
   }
 };
 
-LogicalResult ConvertedAsyncFunctionInfo::postProcess() {
+LogicalResult ConvertedFunctionInfo::postProcess() {
   if (funcOp.isExternal())
     return success();
 
@@ -199,11 +113,6 @@ LogicalResult ConvertedAsyncFunctionInfo::postProcess() {
     case TypeDisposition::IMMUTABLE_TENSOR: {
       if (failed(
               convertImmutableTensorArg(argValue, torchType, preambleBuilder)))
-        return failure();
-      break;
-    }
-    case TypeDisposition::MUTABLE_TENSOR: {
-      if (failed(convertMutableTensorArg(argValue, torchType, preambleBuilder)))
         return failure();
       break;
     }
@@ -234,49 +143,39 @@ LogicalResult ConvertedAsyncFunctionInfo::postProcess() {
     case TypeDisposition::PASSTHROUGH:
       // Do nothing.
       break;
-    case TypeDisposition::FENCE:
-      // Do nothing.
-      break;
     }
   }
 
-  // Materialize synchronization postamble and conversions.
+  // Materialize return conversions.
   IREE::Util::ReturnOp returnOp = returnOps.front();
   SmallVector<Value> newReturnOperands;
   OpBuilder postambleBuilder(returnOp);
   for (auto [disp, returnValue, torchType] : llvm::zip_equal(
            resultDispositions, returnOp.getOperands(), torchResultTypes)) {
-    size_t returnIndex = newReturnOperands.size();
-    newReturnOperands.emplace_back(returnValue);
     switch (disp) {
     case TypeDisposition::IMMUTABLE_TENSOR: {
-      bool needsBarrier = true;
-      if (auto blockArg = dyn_cast<BlockArgument>(returnValue)) {
-        // Trivial return of input. Just pass it through.
-        needsBarrier = blockArg.getOwner() != entryBlock;
-      }
-      if (needsBarrier) {
-        Value source = convertToBuiltinTensor(postambleBuilder, returnValue);
-        addBarrierInput(source, /*storage=*/BlockArgument{}, torchType,
-                        returnIndex);
-      }
+      // Convert back to builtin tensor if needed
+      Value toReturn = convertToBuiltinTensor(postambleBuilder, returnValue);
+      newReturnOperands.push_back(toReturn);
       break;
     }
     case TypeDisposition::TORCH_PRIMITIVE: {
       Location loc = returnValue.getLoc();
       if (isa<Torch::BoolType>(torchType)) {
-        newReturnOperands.back() =
-            postambleBuilder.create<TorchConversion::ToI1Op>(loc, returnValue);
+        newReturnOperands.push_back(
+            postambleBuilder.create<TorchConversion::ToI1Op>(loc, returnValue));
       } else if (isa<Torch::FloatType>(torchType)) {
-        newReturnOperands.back() =
-            postambleBuilder.create<TorchConversion::ToF64Op>(loc, returnValue);
+        newReturnOperands.push_back(
+            postambleBuilder.create<TorchConversion::ToF64Op>(loc,
+                                                              returnValue));
       } else if (isa<Torch::IntType>(torchType)) {
-        newReturnOperands.back() =
-            postambleBuilder.create<TorchConversion::ToI64Op>(loc, returnValue);
+        newReturnOperands.push_back(
+            postambleBuilder.create<TorchConversion::ToI64Op>(loc,
+                                                              returnValue));
       } else if (isa<Torch::GeneratorType>(torchType)) {
-        newReturnOperands.back() =
+        newReturnOperands.push_back(
             postambleBuilder.create<TorchConversion::GeneratorToI64Op>(
-                loc, returnValue);
+                loc, returnValue));
       } else {
         emitError(loc) << "unhandled torch primitive materialization: "
                        << torchType;
@@ -286,61 +185,8 @@ LogicalResult ConvertedAsyncFunctionInfo::postProcess() {
     }
     default: {
       // Non-tensor/converting. Just preserve.
+      newReturnOperands.push_back(returnValue);
     }
-    }
-  }
-
-  // Emit the barrier and exports.
-  // If any of the exports are in-place we need to alias their storage to the
-  // provided buffers.
-  Value coarseSignalFence =
-      entryBlock->getArgument(entryBlock->getNumArguments() - 1);
-  if (barrierInputs.empty()) {
-    postambleBuilder.create<IREE::HAL::FenceSignalOp>(funcOp.getLoc(),
-                                                      coarseSignalFence);
-  } else {
-    SmallVector<Value> aliasedResults;
-    for (auto [barrierInput, meta] :
-         llvm::zip_equal(barrierInputs, barrierResultMeta)) {
-      if (meta.storage) {
-        // Use the wait fence indicating when the storage is available for
-        // mutation. We need to ensure that no writes are made to the storage
-        // until it indicates it's safe to do so.
-        auto storageAffinityAttr =
-            getTorchArgAttr(meta.storage, "iree.abi.affinity");
-        auto waitSignalFences = getEnclosingWaitSignalFences(meta.storage);
-        assert(waitSignalFences && "async function missing fences");
-        Value waitFence = waitSignalFences->first;
-        auto barrierInputDims = IREE::Util::buildDynamicDimsForValue(
-            barrierInput.getLoc(), barrierInput, postambleBuilder);
-        aliasedResults.push_back(
-            postambleBuilder.create<IREE::HAL::TensorAliasOp>(
-                barrierInput.getLoc(), barrierInput.getType(), barrierInput,
-                barrierInputDims, meta.storage, waitFence,
-                storageAffinityAttr));
-      } else {
-        aliasedResults.push_back(barrierInput);
-      }
-    }
-    auto barrierOp = postambleBuilder.create<IREE::HAL::TensorBarrierOp>(
-        funcOp.getLoc(), aliasedResults, coarseSignalFence);
-    for (auto [barrierResult, meta] :
-         llvm::zip_equal(barrierOp.getResults(), barrierResultMeta)) {
-      Attribute exportAffinityAttr;
-      if (meta.storage) {
-        exportAffinityAttr = getTorchArgAttr(meta.storage, "iree.abi.affinity");
-      } else if (meta.returnIndex >= 0) {
-        exportAffinityAttr =
-            getTorchResultAttr(meta.returnIndex, "iree.abi.affinity");
-      }
-      Value exportedValue = postambleBuilder.create<IREE::HAL::TensorExportOp>(
-          funcOp.getLoc(),
-          postambleBuilder.getType<IREE::HAL::BufferViewType>(), barrierResult,
-          TypeAttr::get(barrierResult.getType()), /*name=*/nullptr,
-          exportAffinityAttr);
-      if (meta.returnIndex >= 0) {
-        newReturnOperands[meta.returnIndex] = exportedValue;
-      }
     }
   }
 
@@ -368,7 +214,7 @@ private:
   SmallVector<OpOperand *> originalUses;
 };
 
-LogicalResult ConvertedAsyncFunctionInfo::convertImmutableTensorArg(
+LogicalResult ConvertedFunctionInfo::convertImmutableTensorArg(
     BlockArgument argValue, Type torchType, OpBuilder &builder) {
   Location loc = argValue.getLoc();
 
@@ -383,99 +229,34 @@ LogicalResult ConvertedAsyncFunctionInfo::convertImmutableTensorArg(
   if (!hasNonTrivialUse)
     return success();
 
+  // The type can either be a builtin TensorType or a Torch::ValueTensorType.
+  // If it's already a builtin tensor, nothing to do.
+  if (isa<TensorType>(torchType)) {
+    // Already a builtin tensor type, no conversion needed
+    return success();
+  }
+
   // Remember original uses so we can redirect them.
   OriginalUses originalUses(argValue);
 
-  // The type can either be a builtin TensorType or a Torch::ValueTensorType.
-  // OpBuilder
-  TensorType builtinTensorType;
-  if (auto tType = dyn_cast<TensorType>(torchType)) {
-    builtinTensorType = tType;
-  } else if (auto vtType = dyn_cast<Torch::ValueTensorType>(torchType)) {
-    builtinTensorType = vtType.toBuiltinTensor();
-    if (auto intTy =
-            dyn_cast<IntegerType>(builtinTensorType.getElementType())) {
-      builtinTensorType = builtinTensorType.clone(
-          builder.getIntegerType(intTy.getIntOrFloatBitWidth()));
-    }
-  } else {
-    return emitError(loc) << "unsupported immutable tensor argument: "
-                          << torchType;
+  // Convert from builtin tensor to torch tensor type
+  if (auto vtType = dyn_cast<Torch::ValueTensorType>(torchType)) {
+    Value converted = builder.create<TorchConversion::FromBuiltinTensorOp>(
+        loc, torchType, argValue);
+    originalUses.assign(converted);
+    return success();
   }
 
-  // Propagate explicit affinities and ABI behavior to the read.
-  bool consume = getTorchArgAttr(argValue, "iree.abi.consume") ? true : false;
-  auto affinityAttr = getTorchArgAttr(argValue, "iree.abi.affinity");
-
-  auto waitSignalFences = getEnclosingWaitSignalFences(argValue);
-  assert(waitSignalFences && "async function missing fences");
-  Value waitFence = waitSignalFences->first;
-  Value importedTensor = builder.create<IREE::HAL::TensorImportOp>(
-      loc, builtinTensorType, argValue, TypeAttr::get(builtinTensorType),
-      consume, waitFence,
-      /*name=*/nullptr, affinityAttr);
-  if (builtinTensorType != torchType) {
-    importedTensor = builder.create<TorchConversion::FromBuiltinTensorOp>(
-        loc, torchType, importedTensor);
-  }
-
-  originalUses.assign(importedTensor);
-  return success();
-}
-
-LogicalResult ConvertedAsyncFunctionInfo::convertMutableTensorArg(
-    BlockArgument argValue, Type torchType, OpBuilder &builder) {
-  Location loc = argValue.getLoc();
-  auto fences = getEnclosingWaitSignalFences(argValue);
-  assert(fences && "could not find async fences on func");
-  TensorType builtinTensorType;
-  if (auto t = dyn_cast<TensorType>(torchType)) {
-    builtinTensorType = t;
-  } else {
-    builtinTensorType = cast<Torch::NonValueTensorType>(torchType)
-                            .getWithValueSemantics()
-                            .toBuiltinTensor();
-  }
-
-  // Propagate explicit affinities and ABI behavior to the read and write.
-  auto affinityAttr = getTorchArgAttr(argValue, "iree.abi.affinity");
-
-  // There are only a small set of possible users of a mutable tensor.
-  // Handle them by operation here.
-  SmallVector<Operation *> users(argValue.getUsers());
-  for (auto *userOp : users) {
-    IRRewriter rewriter(loc.getContext());
-    rewriter.setInsertionPoint(userOp);
-    if (auto copyToVtOp = dyn_cast<Torch::CopyToValueTensorOp>(userOp)) {
-      Value imported = rewriter.create<IREE::HAL::TensorImportOp>(
-          loc, builtinTensorType, argValue,
-          /*target_encoding=*/TypeAttr::get(builtinTensorType),
-          /*consume=*/false,
-          /*wait_fence*/ fences->first,
-          /*name=*/nullptr, affinityAttr);
-      rewriter.replaceOpWithNewOp<TorchConversion::FromBuiltinTensorOp>(
-          userOp, copyToVtOp.getResult().getType(), imported);
-    } else if (auto overwriteOp =
-                   dyn_cast<Torch::OverwriteTensorContentsOp>(userOp)) {
-      Value overwriteValue =
-          convertToBuiltinTensor(rewriter, overwriteOp.getValue());
-      addBarrierInput(overwriteValue, /*storage=*/argValue, torchType,
-                      /*returnIndex=*/-1);
-      rewriter.eraseOp(overwriteOp);
-    } else {
-      return emitError(userOp->getLoc())
-             << "unsupported operation on coarse signaling mutable tensor: "
-             << *userOp;
-    }
-  }
-
-  return success();
+  return emitError(loc) << "unsupported immutable tensor argument: "
+                        << torchType;
 }
 
 void retainFunctionAttributes(Operation *srcOp, IREE::Util::FuncOp destOp) {
   // Allowlist of function attributes to retain when importing funcs.
   constexpr const char *kRetainedAttributes[] = {
-      "iree.reflection",
+    "iree.reflection",
+    "iree.abi.affinity",
+    "noinline",
   };
   auto retainedAttributes = ArrayRef<const char *>(
       kRetainedAttributes,
@@ -486,66 +267,6 @@ void retainFunctionAttributes(Operation *srcOp, IREE::Util::FuncOp destOp) {
     if (attr)
       destOp->setAttr(attrName, attr);
   }
-}
-
-void createCoarseFencesSyncWrapper(StringRef syncFunctionName,
-                                   IREE::Util::FuncOp asyncFuncOp,
-                                   IRRewriter &rewriter) {
-  Location loc = asyncFuncOp.getLoc();
-  // The coarse fences wrapper has the same signature as the async variant
-  // but with the last two inputs (wait, signal fence) sliced off.
-  FunctionType asyncFuncType = asyncFuncOp.getFunctionType();
-  SmallVector<Type> inputTypes(asyncFuncType.getInputs().begin(),
-                               asyncFuncType.getInputs().end() - 2);
-
-  // Create the function.
-  auto syncFuncType = rewriter.getType<mlir::FunctionType>(
-      inputTypes, asyncFuncType.getResults());
-  auto syncFuncOp =
-      rewriter.create<IREE::Util::FuncOp>(loc, syncFunctionName, syncFuncType,
-                                          /*tiedOperandsAttr=*/nullptr);
-  syncFuncOp.setSymVisibilityAttr(asyncFuncOp.getSymVisibilityAttr());
-  retainFunctionAttributes(asyncFuncOp, syncFuncOp);
-  syncFuncOp->setAttr("iree.abi.stub", rewriter.getUnitAttr());
-  if (auto affinityAttr = asyncFuncOp->getAttr("iree.abi.affinity")) {
-    syncFuncOp->setAttr("iree.abi.affinity", affinityAttr);
-  }
-  Block *entryBlock = syncFuncOp.addEntryBlock();
-  OpBuilder::InsertionGuard guard(rewriter);
-  rewriter.setInsertionPointToEnd(entryBlock);
-
-  // HACK: this is relying on the fact that there's only one HAL device.
-  // We should instead have a way of creating fences on the device that
-  // is used to produce the tensors we're wrapping.
-  //
-  // TODO(multi-device): emit get with derived ordinal or lookup with attr. We
-  // could always say device 0 for now but could instead look for an
-  // iree.abi.affinity/iree.abi.device/etc.
-  Value timeoutMillis = rewriter.create<arith::ConstantIntOp>(loc, -1, 32);
-  Value device = IREE::HAL::DeviceType::resolveAny(loc, rewriter);
-  Value waitFence = rewriter.create<IREE::Util::NullOp>(
-      loc, rewriter.getType<IREE::HAL::FenceType>());
-  Value signalFence = rewriter.create<IREE::HAL::FenceCreateOp>(
-      loc, rewriter.getType<IREE::HAL::FenceType>(), device,
-      IREE::HAL::FenceFlagBitfield::None);
-
-  SmallVector<Value> callOperands(entryBlock->getArguments());
-  callOperands.push_back(waitFence);
-  callOperands.push_back(signalFence);
-  std::optional<ArrayAttr> targetTiedOperands = asyncFuncOp.getTiedOperands();
-  auto callResults =
-      rewriter
-          .create<IREE::Util::CallOp>(loc, asyncFuncOp, callOperands,
-                                      targetTiedOperands ? *targetTiedOperands
-                                                         : ArrayAttr{})
-          .getResults();
-
-  // Wait forever for signal.
-  rewriter.create<IREE::HAL::FenceAwaitOp>(
-      loc, rewriter.getI32Type(), timeoutMillis,
-      IREE::HAL::WaitFlagBitfield::None, signalFence);
-
-  rewriter.create<IREE::Util::ReturnOp>(loc, callResults);
 }
 
 } // namespace
@@ -568,11 +289,11 @@ public:
     // not yet converted anything "on the inside". Therefore, it is pretty
     // likely the functions are still illegal.
     SmallVector<Operation *> eraseFuncOps;
-    std::vector<ConvertedAsyncFunctionInfo> convertedFuncInfos;
+    std::vector<ConvertedFunctionInfo> convertedFuncInfos;
     for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
       if (!shouldConvertFunc(funcOp))
         continue;
-      ConvertedAsyncFunctionInfo &convertedFuncInfo =
+      ConvertedFunctionInfo &convertedFuncInfo =
           convertedFuncInfos.emplace_back();
       if (failed(convertFuncOp(funcOp, convertedFuncInfo))) {
         signalPassFailure();
@@ -609,33 +330,23 @@ public:
   }
 
   LogicalResult convertFuncOp(func::FuncOp torchFunc,
-                              ConvertedAsyncFunctionInfo &convertedFuncInfo) {
+                              ConvertedFunctionInfo &convertedFuncInfo) {
     IRRewriter rewriter(torchFunc.getContext());
     rewriter.setInsertionPoint(torchFunc);
     Location loc = torchFunc.getLoc();
-    // Determine whether to build pure async or async + sync wrapper.
-    bool generateSyncWrapper = true;
     StringRef originalName = torchFunc.getName();
-    std::string asyncFunctionName = originalName.str();
-    if (generateSyncWrapper) {
-      asyncFunctionName.append("$async");
-    }
 
     // Stash arg/result attrs so they can be referenced during conversion.
     torchFunc.getAllArgAttrs(convertedFuncInfo.torchArgAttrs);
     torchFunc.getAllResultAttrs(convertedFuncInfo.torchResultAttrs);
 
     // Convert function signature.
-    Type fenceType = rewriter.getType<IREE::HAL::FenceType>();
     FunctionType torchFuncType = torchFunc.getFunctionType();
     convertedFuncInfo.torchInputTypes.append(torchFuncType.getInputs().begin(),
                                              torchFuncType.getInputs().end());
     convertedFuncInfo.torchResultTypes.append(
         torchFuncType.getResults().begin(), torchFuncType.getResults().end());
-    // For the coarse-fences ABI, we add two fences to the end. Treat these as
-    // original types so that the lists line up.
-    convertedFuncInfo.torchInputTypes.push_back(fenceType);
-    convertedFuncInfo.torchInputTypes.push_back(fenceType);
+
     SmallVector<Type> ireeInputTypes(convertedFuncInfo.torchInputTypes);
     SmallVector<Type> ireeResultTypes(convertedFuncInfo.torchResultTypes);
     convertedFuncInfo.inputDispositions.resize(ireeInputTypes.size());
@@ -654,7 +365,7 @@ public:
         return failure();
     }
 
-    // Build tied operands index mapping results back to operands.
+        // Build tied operands index mapping results back to operands.
     SmallVector<int64_t> tiedOperands;
     bool anyTiedOperands = false;
     for (unsigned i = 0; i < torchFuncType.getNumResults(); ++i) {
@@ -667,32 +378,41 @@ public:
         tiedOperands.push_back(-1);
       }
     }
+
     auto tiedOperandsAttr = anyTiedOperands
-                                ? rewriter.getIndexArrayAttr(tiedOperands)
-                                : ArrayAttr{};
+                            ? rewriter.getIndexArrayAttr(tiedOperands)
+                            : ArrayAttr{};
 
     // Create new func.
-    FunctionType asyncFuncType =
+    FunctionType syncFuncType =
         FunctionType::get(loc.getContext(), ireeInputTypes, ireeResultTypes);
-    auto asyncFuncOp = rewriter.create<IREE::Util::FuncOp>(
-        torchFunc.getLoc(), asyncFunctionName, asyncFuncType, tiedOperandsAttr);
-    convertedFuncInfo.funcOp = asyncFuncOp;
-    asyncFuncOp.setSymVisibilityAttr(torchFunc.getSymVisibilityAttr());
-    // Handle defacto attrs to specialized ones.
-    asyncFuncOp.setInliningPolicyAttr(
-        rewriter.getAttr<IREE::Util::InlineNeverAttr>());
-    retainFunctionAttributes(torchFunc, asyncFuncOp);
-    asyncFuncOp->setAttr("iree.abi.stub", rewriter.getUnitAttr());
-    asyncFuncOp->setAttr("iree.abi.model",
-                         rewriter.getStringAttr("coarse-fences"));
-    if (auto affinityAttr = torchFunc->getAttr("iree.abi.affinity")) {
-      asyncFuncOp->setAttr("iree.abi.affinity", affinityAttr);
+    auto syncFuncOp = rewriter.create<IREE::Util::FuncOp>(
+        torchFunc.getLoc(), originalName, syncFuncType, tiedOperandsAttr);
+    convertedFuncInfo.funcOp = syncFuncOp;
+    syncFuncOp.setSymVisibilityAttr(torchFunc.getSymVisibilityAttr());
+    retainFunctionAttributes(torchFunc, syncFuncOp);
+
+    // Copy argument attributes
+    for (unsigned i = 0; i < torchFunc.getNumArguments(); ++i) {
+      auto argAttrs = torchFunc.getArgAttrDict(i);
+      if (argAttrs && !argAttrs.empty()) {
+        syncFuncOp.setArgAttrs(i, argAttrs);
+      }
     }
-    rewriter.inlineRegionBefore(
-        torchFunc.getBody(), asyncFuncOp.getFunctionBody(), asyncFuncOp.end());
+
+    // Copy result attributes (including iree.abi.tied)
+    for (unsigned i = 0; i < torchFunc.getNumResults(); ++i) {
+      auto resAttrs = torchFunc.getResultAttrDict(i);
+      if (resAttrs && !resAttrs.empty()) {
+        syncFuncOp.setResultAttrs(i, resAttrs);
+      }
+    }
+
+    rewriter.inlineRegionBefore(torchFunc.getBody(),
+                                syncFuncOp.getFunctionBody(), syncFuncOp.end());
 
     // Convert block arguments.
-    Block *entryBlock = &asyncFuncOp.getBlocks().front();
+    Block *entryBlock = &syncFuncOp.getBlocks().front();
     for (size_t i = 0; i < ireeInputTypes.size(); ++i) {
       // Add if we have extended the list.
       if (i >= entryBlock->getNumArguments()) {
@@ -704,37 +424,42 @@ public:
     }
 
     // Replace return ops.
-    asyncFuncOp->walk([&](func::ReturnOp returnOp) {
+    syncFuncOp->walk([&](func::ReturnOp returnOp) {
       rewriter.setInsertionPoint(returnOp);
       auto ireeReturnOp = rewriter.replaceOpWithNewOp<IREE::Util::ReturnOp>(
           returnOp, returnOp.getOperands());
       convertedFuncInfo.returnOps.push_back(ireeReturnOp);
     });
 
-    // Create the sync variant.
-    rewriter.setInsertionPoint(torchFunc);
-    createCoarseFencesSyncWrapper(originalName, asyncFuncOp, rewriter);
     return success();
   }
 
   LogicalResult convertType(Location loc, Type torchType, Type &ireeType,
                             TypeDisposition &disp) {
-    if (isa<TensorType, Torch::ValueTensorType>(torchType)) {
-      ireeType = IREE::HAL::BufferViewType::get(torchType.getContext());
+    if (isa<TensorType>(torchType)) {
+      // Already a builtin tensor type, just pass through
+      ireeType = torchType;
+      disp = TypeDisposition::IMMUTABLE_TENSOR;
+      return success();
+    }
+
+    if (isa<Torch::ValueTensorType>(torchType)) {
+      // Convert to builtin tensor type
+      auto vtType = cast<Torch::ValueTensorType>(torchType);
+      ireeType = vtType.toBuiltinTensor();
+      if (auto intTy = dyn_cast<IntegerType>(
+              cast<TensorType>(ireeType).getElementType())) {
+        ireeType = cast<TensorType>(ireeType).clone(IntegerType::get(
+            torchType.getContext(), intTy.getIntOrFloatBitWidth()));
+      }
       disp = TypeDisposition::IMMUTABLE_TENSOR;
       return success();
     }
 
     if (isa<Torch::NonValueTensorType>(torchType)) {
-      ireeType = IREE::HAL::BufferViewType::get(torchType.getContext());
-      disp = TypeDisposition::MUTABLE_TENSOR;
-      return success();
-    }
-
-    if (isa<IREE::HAL::FenceType>(torchType)) {
-      ireeType = torchType;
-      disp = TypeDisposition::FENCE;
-      return success();
+      // Mutable tensors are not supported
+      return emitError(loc)
+             << "mutable tensor arguments are not supported: " << torchType;
     }
 
     if (isa<Torch::BoolType>(torchType)) {

--- a/compiler/plugins/input/Torch/InputConversion/test/auto_input_conversion.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/auto_input_conversion.mlir
@@ -14,8 +14,7 @@ func.func @simple_add_onnx(%arg0: !torch.vtensor<[],si64>, %arg1: !torch.vtensor
 // Tests that a function using torch types but not containing any ops is still
 // handled by the torch input pipeline.
 
-// CHECK: util.func public @nop$async
-// CHECK: util.func public @nop(%{{.+}}: !hal.buffer_view) -> !hal.buffer_view
+// CHECK: util.func public @nop(%{{.+}}: tensor<5xf32>) -> tensor<5xf32>
 func.func @nop(%arg0: !torch.vtensor<[5],f32>) -> !torch.vtensor<[5],f32> attributes {torch.assume_strict_symbolic_shapes} {
   return %arg0 : !torch.vtensor<[5],f32>
 }

--- a/compiler/plugins/input/Torch/InputConversion/test/func_conversion.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/func_conversion.mlir
@@ -1,39 +1,17 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(torch-iree-func-conversion)" --allow-unregistered-dialect --split-input-file %s | FileCheck %s
 
-// Canonical test of the immutable input->compute->return case. This is
-// exhaustively verified for both the async and sync wrapper function.
-// There shouldn't be much need to further verify the sync wrapper function.
+// Canonical test of the immutable input->compute->return case.
 // CHECK-LABEL: @immutable_import_export
-//       CHECK: util.func public @main$async(
-//  CHECK-SAME:     %arg0: !hal.buffer_view, %arg1: !hal.buffer_view,
-//  CHECK-SAME:     %arg2: !hal.fence, %arg3: !hal.fence) ->
-//  CHECK-SAME:     (!hal.buffer_view, !hal.buffer_view)
-//  CHECK-SAME:     iree.abi.model = "coarse-fences"
-//  CHECK-SAME:     iree.abi.stub
-//   CHECK-DAG:   %[[WAIT_ARG0:.+]] = hal.tensor.import wait(%arg2) => %arg0 : !hal.buffer_view -> tensor<4x5xi32>
-//   CHECK-DAG:   %[[WAIT_ARG1:.+]] = hal.tensor.import wait(%arg2) => %arg1 : !hal.buffer_view -> tensor<5x4xf32>
-//   CHECK-DAG:   %[[TORCH_ARG0:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG0]] : tensor<4x5xi32> -> !torch.vtensor<[4,5],si32>
-//   CHECK-DAG:   %[[TORCH_ARG1:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG1]] : tensor<5x4xf32> -> !torch.vtensor<[5,4],f32>
+//       CHECK: util.func public @main(
+//  CHECK-SAME:     %arg0: tensor<4x5xi32>, %arg1: tensor<5x4xf32>) ->
+//  CHECK-SAME:     (tensor<4x5xi32>, tensor<5x4xf32>)
+//   CHECK-DAG:   %[[TORCH_ARG0:.+]] = torch_c.from_builtin_tensor %arg0 : tensor<4x5xi32> -> !torch.vtensor<[4,5],si32>
+//   CHECK-DAG:   %[[TORCH_ARG1:.+]] = torch_c.from_builtin_tensor %arg1 : tensor<5x4xf32> -> !torch.vtensor<[5,4],f32>
 //   CHECK-DAG:   %[[TORCH_RESULT0:.+]] = torch.operator "foobar0"(%[[TORCH_ARG0]])
 //   CHECK-DAG:   %[[TORCH_RESULT1:.+]] = torch.operator "foobar1"(%[[TORCH_ARG1]])
 //   CHECK-DAG:   %[[TENSOR_RESULT0:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT0]]
 //   CHECK-DAG:   %[[TENSOR_RESULT1:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT1]]
-//       CHECK:   %[[BARRIER_RESULTS:.+]]:2 = hal.tensor.barrier join(%[[TENSOR_RESULT0]], %[[TENSOR_RESULT1]] : tensor<4x5xi32>, tensor<5x4xf32>) => %arg3
-//   CHECK-DAG:   %[[FUNC_RESULT0:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#0
-//   CHECK-DAG:   %[[FUNC_RESULT1:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#1
-//       CHECK:   util.return %[[FUNC_RESULT0]], %[[FUNC_RESULT1]]
-//
-//       CHECK: util.func public @main(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view)
-//  CHECK-SAME:     -> (!hal.buffer_view, !hal.buffer_view)
-//  CHECK-SAME:     iree.abi.stub
-//   CHECK-DAG:   %[[CONSTANT0:.+]] = arith.constant 0 : index
-//   CHECK-DAG:   %[[CONSTANT1:.+]] = arith.constant -1 : i32
-//   CHECK-DAG:   %[[DEVICE0:.+]] = hal.devices.get %[[CONSTANT0]] : !hal.device
-//   CHECK-DAG:   %[[NULL_FENCE:.+]] = util.null : !hal.fence
-//       CHECK:   %[[NEW_FENCE:.+]] = hal.fence.create device(%[[DEVICE0]] : !hal.device) flags("None")
-//       CHECK:   %[[CALL_RESULTS:.+]]:2 = util.call @main$async(%arg0, %arg1, %[[NULL_FENCE]], %[[NEW_FENCE]])
-//       CHECK:   %[[AWAIT_STATUS:.+]] = hal.fence.await until([%[[NEW_FENCE]]]) timeout_millis(%[[CONSTANT1]])
-//       CHECK:   util.return %[[CALL_RESULTS]]#0, %[[CALL_RESULTS]]#1 : !hal.buffer_view, !hal.buffer_view
+//       CHECK:   util.return %[[TENSOR_RESULT0]], %[[TENSOR_RESULT1]]
 builtin.module @immutable_import_export {
 func.func @main(%arg0: !torch.vtensor<[4,5],si32>, %arg1: !torch.vtensor<[5,4],f32>)
     -> (!torch.vtensor<[4,5],si32>, !torch.vtensor<[5,4],f32>) {
@@ -45,8 +23,8 @@ func.func @main(%arg0: !torch.vtensor<[4,5],si32>, %arg1: !torch.vtensor<[5,4],f
 
 // -----
 // CHECK-LABEL: @return_immutable_arg
-// CHECK: util.func public @main$async
-// CHECK: hal.fence.signal<%arg2 : !hal.fence>
+// CHECK: util.func public @main(
+// CHECK-SAME: %arg0: tensor<4x5xi32>) -> tensor<4x5xi32>
 // CHECK: util.return %arg0
 builtin.module @return_immutable_arg {
 func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>  {
@@ -55,96 +33,7 @@ func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>
 }
 
 // -----
-// Tests the immutable + mutable argument case where the mutable argument is
-// overwritten as part of the function cleanup and the argument is not returned.
-// This exhaustively verifies the async function.
-// Note that the order of the barrier operands and successors is implementation
-// dependent, and the current implementation processes mutable before
-// immutable.
-// CHECK-LABEL: @mutable_input_overwrite_no_return
-//       CHECK: util.func public @main$async(
-//  CHECK-SAME:     %arg0: !hal.buffer_view, %arg1: !hal.buffer_view,
-//  CHECK-SAME:     %arg2: !hal.fence, %arg3: !hal.fence) -> !hal.buffer_view
-//   CHECK-DAG: %[[WAIT_ARG0:.+]] = hal.tensor.import wait(%arg2) => %arg0
-//   CHECK-DAG: %[[TORCH_ARG0:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG0]]
-//   CHECK-DAG: %[[WAIT_ARG1:.+]] = hal.tensor.import wait(%arg2) => %arg1
-//   CHECK-DAG: %[[TORCH_ARG1:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG1]]
-//   CHECK-DAG: %[[TORCH_RESULT0:.+]] = torch.operator "other_calc"(%[[TORCH_ARG0]])
-//   CHECK-DAG: %[[TORCH_RESULT1:.+]] = torch.operator "mutate_inplace"(%[[TORCH_ARG1]])
-//   CHECK-DAG: %[[TENSOR_ARG0:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT0]]
-//   CHECK-DAG: %[[TENSOR_ARG1:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT1]]
-//       CHECK: %[[EXPORT_ALIAS1:.+]] = hal.tensor.alias wait(%arg2) => %[[TENSOR_ARG1]] : tensor<5x4xf32> to %arg1 : !hal.buffer_view
-//       CHECK: %[[BARRIER_RESULTS:.+]]:2 = hal.tensor.barrier join(%[[EXPORT_ALIAS1]], %[[TENSOR_ARG0]] : tensor<5x4xf32>, tensor<4x5xi32>) => %arg3 : !hal.fence
-//   CHECK-DAG: %[[EXPORT_RESULT0:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#0
-//   CHECK-DAG: %[[EXPORT_RESULT1:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#1
-//       CHECK: util.return %[[EXPORT_RESULT1]]
-builtin.module @mutable_input_overwrite_no_return {
-func.func @main(%arg0: !torch.vtensor<[4,5],si32>, %arg1: !torch.tensor<[5,4],f32>)
-    -> (!torch.vtensor<[4,5],si32>) {
-  %0 = torch.copy.to_vtensor %arg1 : !torch.vtensor<[5,4],f32>
-  %1 = torch.operator "mutate_inplace"(%0) : (!torch.vtensor<[5,4],f32>) -> !torch.vtensor<[5,4],f32>
-  %2 = torch.operator "other_calc"(%arg0) : (!torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>
-  torch.overwrite.tensor.contents %1 overwrites %arg1 : !torch.vtensor<[5,4],f32>, !torch.tensor<[5,4],f32>
-  return %2 : !torch.vtensor<[4,5],si32>
-}
-}
-
-// -----
-// This isn't a great program to write but is legal. It verifies that if the
-// function returns an intermediate vtensor just before it was noted as mutated
-// that we export it properly. This would be a hard program to write in PyTorch
-// but possible to end up this way so testing the corner.
-// Not a good idea to do but legal. This verifies that if returning a mutated
-// tensor's intermediate value, you will get two exports, indicating a copy.
-// CHECK-LABEL: @mutable_input_overwrite_return_alias_copies
-//       CHECK: %[[ALIASED:.+]] = hal.tensor.alias wait({{.+}}) => %{{.+}} : tensor<5x4xf32> to %arg0 : !hal.buffer_view
-//       CHECK: %[[BARRIER_RESULTS:.+]]:2 = hal.tensor.barrier join(%[[ALIASED]], %{{.*}} : tensor<5x4xf32>, tensor<5x4xf32>)
-//   CHECK-DAG: = hal.tensor.export %[[BARRIER_RESULTS]]#0
-//   CHECK-DAG: = hal.tensor.export %[[BARRIER_RESULTS]]#1
-builtin.module @mutable_input_overwrite_return_alias_copies {
-func.func @main(%arg0: !torch.tensor<[5,4],f32>) -> (!torch.vtensor<[5,4],f32>) {
-  %0 = torch.copy.to_vtensor %arg0 : !torch.vtensor<[5,4],f32>
-  %1 = torch.operator "mutate_inplace"(%0) : (!torch.vtensor<[5,4],f32>) -> !torch.vtensor<[5,4],f32>
-  torch.overwrite.tensor.contents %1 overwrites %arg0 : !torch.vtensor<[5,4],f32>, !torch.tensor<[5,4],f32>
-  return %1 : !torch.vtensor<[5,4],f32>
-}
-}
-
-// -----
-// Tests the immutable + mutable argument case with explicit affinities.
-// CHECK-LABEL: @mutable_input_overwrite_no_return
-//       CHECK: util.func public @main$async(
-//  CHECK-SAME:     %arg0: !hal.buffer_view, %arg1: !hal.buffer_view,
-//  CHECK-SAME:     %arg2: !hal.fence, %arg3: !hal.fence) -> !hal.buffer_view
-//   CHECK-DAG: %[[WAIT_ARG0:.+]] = hal.tensor.import on(#hal.device.promise<@dev_a>) wait(%arg2) => %arg0
-//   CHECK-DAG: %[[TORCH_ARG0:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG0]]
-//   CHECK-DAG: %[[WAIT_ARG1:.+]] = hal.tensor.import on(#hal.device.promise<@dev_b>) wait(%arg2) => %arg1
-//   CHECK-DAG: %[[TORCH_ARG1:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG1]]
-//   CHECK-DAG: %[[TORCH_RESULT0:.+]] = torch.operator "other_calc"(%[[TORCH_ARG0]])
-//   CHECK-DAG: %[[TORCH_RESULT1:.+]] = torch.operator "mutate_inplace"(%[[TORCH_ARG1]])
-//   CHECK-DAG: %[[TENSOR_ARG0:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT0]]
-//   CHECK-DAG: %[[TENSOR_ARG1:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT1]]
-//       CHECK: %[[EXPORT_ALIAS1:.+]] = hal.tensor.alias on(#hal.device.promise<@dev_b>) wait(%arg2) => %[[TENSOR_ARG1]] : tensor<5x4xf32> to %arg1 : !hal.buffer_view
-//       CHECK: %[[BARRIER_RESULTS:.+]]:2 = hal.tensor.barrier join(%[[EXPORT_ALIAS1]], %[[TENSOR_ARG0]] : tensor<5x4xf32>, tensor<4x5xi32>) => %arg3 : !hal.fence
-//   CHECK-DAG: %[[EXPORT_RESULT0:.+]] = hal.tensor.export on(#hal.device.promise<@dev_b>) %[[BARRIER_RESULTS]]#0
-//   CHECK-DAG: %[[EXPORT_RESULT1:.+]] = hal.tensor.export on(#hal.device.promise<@dev_a>) %[[BARRIER_RESULTS]]#1
-//       CHECK: util.return %[[EXPORT_RESULT1]]
-builtin.module @mutable_input_overwrite_no_return_affinities {
-func.func @main(%arg0: !torch.vtensor<[4,5],si32> {iree.abi.affinity = #hal.device.promise<@dev_a>},
-                %arg1: !torch.tensor<[5,4],f32> {iree.abi.affinity = #hal.device.promise<@dev_b>})
-    -> (!torch.vtensor<[4,5],si32> {iree.abi.affinity = #hal.device.promise<@dev_a>}) {
-  %0 = torch.copy.to_vtensor %arg1 : !torch.vtensor<[5,4],f32>
-  %1 = torch.operator "mutate_inplace"(%0) : (!torch.vtensor<[5,4],f32>) -> !torch.vtensor<[5,4],f32>
-  %2 = torch.operator "other_calc"(%arg0) : (!torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>
-  torch.overwrite.tensor.contents %1 overwrites %arg1 : !torch.vtensor<[5,4],f32>, !torch.tensor<[5,4],f32>
-  return %2 : !torch.vtensor<[4,5],si32>
-}
-}
-
-// -----
 // CHECK-LABEL: @retained_attribute_reflection
-//      CHECK: util.func public @main$async(
-// CHECK-SAME:   iree.reflection = {some.attr = 4 : index}
 //      CHECK: util.func public @main(
 // CHECK-SAME:   iree.reflection = {some.attr = 4 : index}
 builtin.module @retained_attribute_reflection {
@@ -161,7 +50,7 @@ func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>
 
 // -----
 // CHECK-LABEL: @retained_attribute_ignored
-//      CHECK: util.func public @main$async(
+//      CHECK: util.func public @main(
 //  CHECK-NOT: iree.nonretained
 builtin.module @retained_attribute_ignored {
 func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>
@@ -175,10 +64,8 @@ func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>
 
 // -----
 // CHECK-LABEL: @retained_attribute_noinline
-//      CHECK: util.func public @main$async(
-// CHECK-SAME:   inlining_policy = #util.inline.never
 //      CHECK: util.func public @main(
-// CHECK-NOT:    inlining_policy
+// CHECK-SAME:   noinline
 builtin.module @retained_attribute_noinline {
 func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>
   attributes {
@@ -191,7 +78,6 @@ func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>
 
 // -----
 // CHECK-LABEL: @private_visibility
-// CHECK: util.func private @main$async
 // CHECK: util.func private @main
 builtin.module @private_visibility {
 func.func private @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>
@@ -202,9 +88,8 @@ func.func private @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,
 
 // -----
 // CHECK-LABEL: @tied_operand
-// CHECK: util.func public @main$async(%arg0: !hal.buffer_view, %arg1: !hal.fence, %arg2: !hal.fence) -> %arg0
-// CHECK: util.func public @main(%arg0: !hal.buffer_view) -> !hal.buffer_view
-// CHECK: = util.call @main$async{{.*}} -> %arg0
+// CHECK: util.func public @main(%arg0: tensor<4x5xi32>) -> (%arg0 {iree.abi.tied = 0 : i64})
+// CHECK: util.return %arg0
 builtin.module @tied_operand {
 func.func @main(%arg0: !torch.vtensor<[4,5],si32>) ->
   (!torch.vtensor<[4,5],si32> {iree.abi.tied = 0})
@@ -214,11 +99,10 @@ func.func @main(%arg0: !torch.vtensor<[4,5],si32>) ->
 }
 
 // -----
-// Verify that dynamic dimensions verify.
-// CHECK-LABEL: @immutable_import_export
-// CHECK: hal.buffer_view.dim<%arg0
-// CHECK: hal.buffer_view.dim<%arg1
-builtin.module @immutable_import_export {
+// Verify that dynamic dimensions work.
+// CHECK-LABEL: @immutable_import_export_dynamic
+// CHECK: util.func public @main(%arg0: tensor<4x?xi32>, %arg1: tensor<?x4xf32>)
+builtin.module @immutable_import_export_dynamic {
 func.func @main(%arg0: !torch.vtensor<[4,?],si32>, %arg1: !torch.vtensor<[?,4],f32>)
     -> (!torch.vtensor<[4,?],si32>, !torch.vtensor<[?,4],f32>) {
   %0 = torch.operator "foobar0"(%arg0) : (!torch.vtensor<[4,?],si32>) -> !torch.vtensor<[4,?],si32>
@@ -352,5 +236,21 @@ module @builtin_float_return {
   func.func @main() -> f32 {
     %0 = "torch_test.operator"() : () -> f32
     return %0 : f32
+  }
+}
+
+// -----
+// CHECK-LABEL: @device_affinity_preserved
+// CHECK: util.func public @main(
+// CHECK-SAME:   %arg0: tensor<2x2xf32> {iree.abi.affinity = #hal.device.affinity<@device_a>},
+// CHECK-SAME:   %arg1: tensor<2x2xf32> {iree.abi.affinity = #hal.device.affinity<@device_b>})
+// CHECK-SAME:   -> (tensor<2x2xf32> {iree.abi.affinity = #hal.device.affinity<@device_c>})
+module @device_affinity_preserved {
+  func.func @main(%arg0: !torch.vtensor<[2,2],f32> {iree.abi.affinity = #hal.device.affinity<@device_a>},
+                  %arg1: !torch.vtensor<[2,2],f32> {iree.abi.affinity = #hal.device.affinity<@device_b>})
+                  -> (!torch.vtensor<[2,2],f32> {iree.abi.affinity = #hal.device.affinity<@device_c>})
+                  attributes {torch.assume_strict_symbolic_shapes} {
+    %0 = torch.operator "some.operation"(%arg0, %arg1) : (!torch.vtensor<[2,2],f32>, !torch.vtensor<[2,2],f32>) -> !torch.vtensor<[2,2],f32>
+    return %0 : !torch.vtensor<[2,2],f32>
   }
 }

--- a/compiler/plugins/input/Torch/InputConversion/test/func_conversion_invalid.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/func_conversion_invalid.mlir
@@ -4,11 +4,11 @@
 // It is unclear if these can be generated from current torch tooling. If it
 // ever becomes a problem, something can be implemented.
 builtin.module @mutable_input_overwrite_return {
+// expected-error @+1 {{mutable tensor arguments are not supported: '!torch.tensor<[5,4],f32>'}}
 func.func @main(%arg0: !torch.tensor<[5,4],f32>) -> (!torch.tensor<[5,4],f32>) {
   %0 = torch.copy.to_vtensor %arg0 : !torch.vtensor<[5,4],f32>
   %1 = torch.operator "mutate_inplace"(%0) : (!torch.vtensor<[5,4],f32>) -> !torch.vtensor<[5,4],f32>
   torch.overwrite.tensor.contents %1 overwrites %arg0 : !torch.vtensor<[5,4],f32>, !torch.tensor<[5,4],f32>
-  // expected-error @+1 {{unsupported operation on coarse signaling mutable tensor}}
   return %arg0 : !torch.tensor<[5,4],f32>
 }
 }

--- a/compiler/plugins/input/Torch/InputConversion/test/torch_to_iree.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/torch_to_iree.mlir
@@ -4,7 +4,7 @@
 
 // Verify that we can have IREE ops in the input and the types convert
 // properly.
-// CHECK-LABEL: util.func public @forward$async(%arg0: !hal.buffer_view, %arg1: !hal.fence, %arg2: !hal.fence) -> !hal.buffer_view
+// CHECK-LABEL: util.func public @forward(%arg0: tensor<128x20xf32>) -> tensor<128x30xf32>
 // CHECK: linalg.matmul
 func.func @forward(%arg0: !torch.vtensor<[128,20],f32>) -> !torch.vtensor<[128,30],f32> {
   %_params.classifier.weight = util.global.load @_params.classifier.weight : tensor<30x20xf32>
@@ -29,7 +29,7 @@ util.global private @_params.classifier.bias {inlining_policy = #util.inline.nev
 // -----
 
 // Verify we can decompose complex ops
-// CHECK-LABEL: util.func public @main$async(%arg0: !hal.buffer_view, %arg1: !hal.fence, %arg2: !hal.fence) -> (!hal.buffer_view, !hal.buffer_view)
+// CHECK-LABEL: util.func public @main(%arg0: tensor<2x3x4xf32>) -> (tensor<2x3x4xf32>, tensor<2x3x4xf32>)
 // CHECK: tensor.empty
 func.func @main(%arg0: !torch.vtensor<[2,3,4],f32>) -> (!torch.vtensor<[2,3,4],f32>, !torch.vtensor<[2,3,4],f32>) {
   %int2 = torch.constant.int 2


### PR DESCRIPTION
Why this change?

torch imported models were not compilable for bare metal deployments since the torch conversion did insert ops during the conversion that are not possible to lower to the inline HAL.

roof-mlir CI run: https://github.com/RooflineAI/roof-mlir/runs/44480755774

Overview:

This PR removes two 2 core parts from the torch-to-iree function conversion.

1. No more implicit Async function generation
2. No longer support mutable torch tensors 
