### PR TITLE
fix(iree): disable obsolete AMDGPU HAL driver build

### DIFF
--- a/runtime/src/iree/hal/drivers/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/BUILD.bazel
@@ -16,7 +16,8 @@ package(
 string_list_flag(
     name = "enabled_drivers",
     build_setting_default = [
-        "amdgpu",
+        # ROO-487: disabled target
+        # "amdgpu",
         "cuda",
         "local-sync",
         "local-task",


### PR DESCRIPTION
Disable the target for now to duck the LLVM/Clang dependency for ROCM bitcode modules.

This is in the aftermath of [iree-org/iree@a123c8b](https://github.com/iree-org/iree/commit/a123c8b58aa9bc5cc4320f9046a933a037c11c6a), [iree-org/iree@bc5e67eb](https://github.com/iree-org/iree/commit/bc5e67eb0bf98418545792d1c3a024c5c368db4f).