### PR TITLE
torch sync conversion

### DIFF
--- a/compiler/plugins/input/Torch/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.cpp
@@ -82,7 +82,9 @@ void createTorchToIREEPipeline(
   // differently and would not be subject to inlining.
   pm.addPass(mlir::createInlinerPass());
 
-  pm.addPass(createFuncConversionPass());
+  FuncConversionPassOptions funcOptions;
+  funcOptions.generateAsyncFunctions = options.emitAsyncEntryPoints;
+  pm.addPass(createFuncConversionPass(funcOptions));
   pm.addNestedPass<IREE::Util::FuncOp>(createCanonicalizerPass());
   pm.addPass(createSymbolDCEPass());
 

--- a/compiler/plugins/input/Torch/InputConversion/Passes.h
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.h
@@ -35,6 +35,11 @@ struct TorchToIREELoweringPipelineOptions
   Option<bool> decompose{*this, "decompose",
                          llvm::cl::desc("Decompose complex torch operations."),
                          llvm::cl::init(true)};
+  Option<bool> emitAsyncEntryPoints{
+      *this, "emit-async-entry-points",
+      llvm::cl::desc("Generate async functions with coarse-fences ABI. When "
+                     "false (default), generates only sync functions."),
+      llvm::cl::init(false)};
 };
 
 // Creates a pipeline that lowers from the torch backend contract to IREE.

--- a/compiler/plugins/input/Torch/InputConversion/Passes.td
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.td
@@ -41,6 +41,12 @@ def FuncConversionPass :
     Conversion pass for finalizing functions and ABI. Replaces the generic
     torch-func-backend-type-conversion pass.
   }];
+  let options = [
+    Option<"generateAsyncFunctions", "generate-async-functions", "bool",
+           /*default=*/"true",
+           "Generate async functions with coarse-fences ABI. "
+           "When false, generates only sync functions.">
+  ];
 }
 
 #endif // IREE_COMPILER_PLUGINS_INPUT_TORCH_INPUTCONVERSION_PASSES

--- a/compiler/plugins/input/Torch/InputConversion/test/auto_input_conversion.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/auto_input_conversion.mlir
@@ -14,7 +14,6 @@ func.func @simple_add_onnx(%arg0: !torch.vtensor<[],si64>, %arg1: !torch.vtensor
 // Tests that a function using torch types but not containing any ops is still
 // handled by the torch input pipeline.
 
-// CHECK: util.func public @nop$async
 // CHECK: util.func public @nop(%{{.+}}: !hal.buffer_view) -> !hal.buffer_view
 func.func @nop(%arg0: !torch.vtensor<[5],f32>) -> !torch.vtensor<[5],f32> attributes {torch.assume_strict_symbolic_shapes} {
   return %arg0 : !torch.vtensor<[5],f32>

--- a/compiler/plugins/input/Torch/InputConversion/test/func_conversion_invalid.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/func_conversion_invalid.mlir
@@ -8,7 +8,7 @@ func.func @main(%arg0: !torch.tensor<[5,4],f32>) -> (!torch.tensor<[5,4],f32>) {
   %0 = torch.copy.to_vtensor %arg0 : !torch.vtensor<[5,4],f32>
   %1 = torch.operator "mutate_inplace"(%0) : (!torch.vtensor<[5,4],f32>) -> !torch.vtensor<[5,4],f32>
   torch.overwrite.tensor.contents %1 overwrites %arg0 : !torch.vtensor<[5,4],f32>, !torch.tensor<[5,4],f32>
-  // expected-error @+1 {{unsupported operation on coarse signaling mutable tensor}}
+  // expected-error @+1 {{unsupported operation on mutable tensor}}
   return %arg0 : !torch.tensor<[5,4],f32>
 }
 }

--- a/compiler/plugins/input/Torch/InputConversion/test/torch_to_iree.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/torch_to_iree.mlir
@@ -4,7 +4,7 @@
 
 // Verify that we can have IREE ops in the input and the types convert
 // properly.
-// CHECK-LABEL: util.func public @forward$async(%arg0: !hal.buffer_view, %arg1: !hal.fence, %arg2: !hal.fence) -> !hal.buffer_view
+// CHECK-LABEL: util.func public @forward(%arg0: !hal.buffer_view) -> !hal.buffer_view
 // CHECK: linalg.matmul
 func.func @forward(%arg0: !torch.vtensor<[128,20],f32>) -> !torch.vtensor<[128,30],f32> {
   %_params.classifier.weight = util.global.load @_params.classifier.weight : tensor<30x20xf32>
@@ -29,7 +29,7 @@ util.global private @_params.classifier.bias {inlining_policy = #util.inline.nev
 // -----
 
 // Verify we can decompose complex ops
-// CHECK-LABEL: util.func public @main$async(%arg0: !hal.buffer_view, %arg1: !hal.fence, %arg2: !hal.fence) -> (!hal.buffer_view, !hal.buffer_view)
+// CHECK-LABEL: util.func public @main(%arg0: !hal.buffer_view) -> (!hal.buffer_view, !hal.buffer_view)
 // CHECK: tensor.empty
 func.func @main(%arg0: !torch.vtensor<[2,3,4],f32>) -> (!torch.vtensor<[2,3,4],f32>, !torch.vtensor<[2,3,4],f32>) {
   %int2 = torch.constant.int 2

--- a/compiler/plugins/input/Torch/PluginRegistration.cpp
+++ b/compiler/plugins/input/Torch/PluginRegistration.cpp
@@ -28,6 +28,7 @@ namespace {
 struct TorchOptions {
   bool strictSymbolicShapes = true;
   bool decompose = true;
+  bool emitAsyncEntryPoints = false;
   void bindOptions(OptionsBinder &binder) {
     static llvm::cl::OptionCategory category("Torch Input");
     binder.opt<bool>(
@@ -37,6 +38,11 @@ struct TorchOptions {
     binder.opt<bool>("iree-torch-decompose-complex-ops", decompose,
                      llvm::cl::cat(category),
                      llvm::cl::desc("Decompose complex torch operations."));
+    binder.opt<bool>(
+        "iree-torch-emit-async-entry-points", emitAsyncEntryPoints,
+        llvm::cl::cat(category),
+        llvm::cl::desc("Generate async functions with coarse-fences ABI. When "
+                       "false (default), generates only sync functions."));
   }
 };
 
@@ -85,6 +91,7 @@ struct TorchSession
       TorchInput::TorchToIREELoweringPipelineOptions torchOptions;
       torchOptions.strictSymbolicShapes = options.strictSymbolicShapes;
       torchOptions.decompose = options.decompose;
+      torchOptions.emitAsyncEntryPoints = options.emitAsyncEntryPoints;
       TorchInput::createTorchToIREEPipeline(passManager, torchOptions);
       return true;
     }


### PR DESCRIPTION
alternative to https://app.graphite.dev/github/pr/RooflineAI/iree/83/remove-mutable-args-and-async-function-created-from-torch-funcConversion. Keeps basically all the original behavior but defaults to only creating a sync entry point. However this is a bit ugly as i have to use (abuse?) the optimization barrier op as otherwise the alias +export op of the mutated arg gets DCE'd.

Have integration tests here: https://app.graphite.dev/github/pr/RooflineAI/roof-mlir/460/update-submodule-to-new-torch-functionConversion, 

but some (unrelated) CI problems currently which should be fixed soon.

