### PR TITLE
fix(iree): disable obsolete AMDGPU HAL driver build (#84)

### DIFF
--- a/compiler/bindings/python/iree/compiler/__init__.py
+++ b/compiler/bindings/python/iree/compiler/__init__.py
@@ -9,3 +9,21 @@
 # Re-export some legacy APIs from the tools package to this top-level.
 # TODO: Deprecate and remove these names once clients are migrated.
 from .tools import *
+
+# Roofline AI ->
+import sys
+
+if sys.version_info[:2] >= (3, 8):
+    from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
+else:
+    from importlib_metadata import PackageNotFoundError, version  # pragma: no cover
+
+try:
+    # Note that the package name must be kept in sync with
+    # roof-iree/runtime/BUILD.bazel
+    __version__ = version("iree_compiler_bazel")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"
+finally:
+    del version, PackageNotFoundError
+# <- Roofline AI

--- a/runtime/bindings/python/iree/runtime/__init__.py
+++ b/runtime/bindings/python/iree/runtime/__init__.py
@@ -77,3 +77,21 @@ from .function import *
 from .io import *
 
 from . import flags
+
+# Roofline AI ->
+import sys
+
+if sys.version_info[:2] >= (3, 8):
+    from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
+else:
+    from importlib_metadata import PackageNotFoundError, version  # pragma: no cover
+
+try:
+    # Note that the package name must be kept in sync with
+    # roof-iree/runtime/BUILD.bazel
+    __version__ = version("iree_runtime_bazel")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"
+finally:
+    del version, PackageNotFoundError
+# <- Roofline AI


### PR DESCRIPTION
fix(iree): disable obsolete AMDGPU HAL driver build (#84)

Disable the target for now to duck the LLVM/Clang dependency for ROCM bitcode modules.

This is in the aftermath of [iree-org/iree@a123c8b](https://github.com/iree-org/iree/commit/a123c8b58aa9bc5cc4320f9046a933a037c11c6a), [iree-org/iree@bc5e67eb](https://github.com/iree-org/iree/commit/bc5e67eb0bf98418545792d1c3a024c5c368db4f).

Fix bazel amdgpu build (#82)

runtime/src/iree/task: fix: cpuinfo is not available on all platforms

runtime/src/iree/task: fix: cpuinfo is not available on all platforms (#85)

Fixes that enable cross-compilation of iree runtime for RISC-V 64bit

python bindings: add version to __init__.py files