### PR TITLE
build_tools/bazel: disable CUDA for aarch64

### DIFF
--- a/build_tools/bazel/workspace.bzl
+++ b/build_tools/bazel/workspace.bzl
@@ -29,7 +29,7 @@ def cuda_auto_configure_impl(repository_ctx):
     if script_file:
         # Only support Linux and Windows.
         # (Assuming repository_ctx.os.name returns a lowercase string like "linux" or "windows".)
-        if repository_ctx.os.name.lower() not in ["linux", "windows"]:
+        if repository_ctx.os.arch.lower() not in ["x86_64"] or repository_ctx.os.name.lower() not in ["linux", "windows"]:
             repository_ctx.file("BUILD", """
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 package(default_visibility = ["//visibility:public"])
@@ -37,7 +37,7 @@ bool_flag(
     name = "enabled",
     build_setting_default = False,
 )""")
-            print("CUDA auto configuration downloading is only supported on Linux and Windows, but the current OS is: " + repository_ctx.os.name)
+            print("CUDA auto configuration downloading is only supported on x86_64 Linux and Windows, but the current platform is: " + repository_ctx.os.name + " " + repository_ctx.os.arch)
             return
         # Link and run the download script.
         script_path = repository_ctx.path(script_file)


### PR DESCRIPTION
Disable CUDA for aarch64, not supported